### PR TITLE
Add hint in faq about anonymous fifo

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -6,6 +6,9 @@
 - `ytt -f config/ | kapp deploy -a app1 -f- -c -y`
   - Deploy app named `app1` with configuration piped in
 
+- `kapp deploy -a app1 -f- <(ytt -f config/ )`
+  - Deploy app named `app1` with configuration generated inline and with confirmation dialog
+
 - `kapp deploy -a app1 -f config/ -c --diff-context=10`
   - Show more diff context when reviewing changes during deploy
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ### `Error: Asking for confirmation: EOF`
 
-This probably means you have piped configuration into kapp and did not specify `--yes` (`-y`) flag to continue. It's necessary because kapp can no longer ask for confirmation via stdin. Feel free to re-run the command with `--diff-changes` (`-c`) to make sure pending changes are correct.
+This probably means you have piped configuration into kapp and did not specify `--yes` (`-y`) flag to continue. It's necessary because kapp can no longer ask for confirmation via stdin. Feel free to re-run the command with `--diff-changes` (`-c`) to make sure pending changes are correct. Instead of using a pipe you can also use an anonymous fifo keeping stdin free for the confirmation prompt, e.g. `kapp deploy -a app1 -f <(ytt -f config/)`
 
 ---
 ### Where to store app resources (i.e. in which namespace)?


### PR DESCRIPTION
Instead of always using `-y` and a pipe, it might be better to use an anonymous fifo. That way users get the confirmation dialog with the convenience of a one-liner to generate and apply a manifest.