### PR TITLE
fix help for -a to correctly include label:name=key

### DIFF
--- a/pkg/kapp/cmd/app/app_flags.go
+++ b/pkg/kapp/cmd/app/app_flags.go
@@ -13,5 +13,5 @@ type AppFlags struct {
 func (s *AppFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
 	s.NamespaceFlags.Set(cmd, flagsFactory)
 
-	cmd.Flags().StringVarP(&s.Name, "app", "a", "", "Set app name (or label selector) (format: name, key=val, !key)")
+	cmd.Flags().StringVarP(&s.Name, "app", "a", "", "Set app name (or label selector) (format: name, label:key=val, !key)")
 }


### PR DESCRIPTION
Current help for `logs` command `-a` option is missing `label` in format. So changing:

```bash
➜  kapp git:(logs-a-label) ./kapp logs -h
Print app's Pod logs

Usage:
  kapp logs [flags]

Aliases:
  logs, l

Flags:
  -a, --app string         Set app name (or label selector) (format: name, key=val, !key)
...
```

to

```bash
➜  kapp git:(logs-a-label) ./kapp logs -h
Print app's Pod logs

Usage:
  kapp logs [flags]

Aliases:
  logs, l

Flags:
  -a, --app string         Set app name (or label selector) (format: name, label:key=val, !key)
...
```

which is the correct way of specifying a `label` selector.