### PR TITLE
Allow kapp binary path to be configured in e2e tests

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -3,6 +3,9 @@
 set -e -x -u
 
 ./hack/build.sh
+
+export KAPP_BINARY_PATH="$PWD/kapp"
+
 ./hack/test.sh
 ./hack/test-e2e.sh
 

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -4,6 +4,8 @@ set -e -x -u
 
 go clean -testcache
 
+export KAPP_BINARY_PATH="${KAPP_BINARY_PATH:-$PWD/kapp}"
+
 go test ./test/e2e/ -timeout 60m -test.v $@
 
 echo E2E SUCCESS

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -11,7 +11,7 @@ import (
 func TestConfig(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 	kubectl := Kubectl{t, env.Namespace, logger}
 
 	config := `

--- a/test/e2e/create_update_delete_test.go
+++ b/test/e2e/create_update_delete_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateUpdateDelete(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 	kubectl := Kubectl{t, env.Namespace, logger}
 
 	yaml1 := `

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -11,7 +11,7 @@ import (
 func TestDiff(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	yaml1 := `
 ---

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -7,12 +7,19 @@ import (
 )
 
 type Env struct {
-	Namespace string
+	Namespace      string
+	KappBinaryPath string
 }
 
 func BuildEnv(t *testing.T) Env {
+	kappPath := os.Getenv("KAPP_BINARY_PATH")
+	if kappPath == "" {
+		kappPath = "kapp"
+	}
+
 	env := Env{
-		Namespace: os.Getenv("KAPP_E2E_NAMESPACE"),
+		Namespace:      os.Getenv("KAPP_E2E_NAMESPACE"),
+		KappBinaryPath: kappPath,
 	}
 	env.Validate(t)
 	return env

--- a/test/e2e/ignore_failing_api_services_flag_test.go
+++ b/test/e2e/ignore_failing_api_services_flag_test.go
@@ -11,7 +11,7 @@ import (
 func TestIgnoreFailingAPIServicesFlag(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	yaml1 := `
 ---

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -11,7 +11,7 @@ import (
 func TestInspect(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	yaml1 := `
 ---

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -13,6 +13,7 @@ import (
 type Kapp struct {
 	t         *testing.T
 	namespace string
+	kappPath  string
 	l         Logger
 }
 
@@ -46,8 +47,7 @@ func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 
 	k.l.Debugf("Running '%s'...\n", k.cmdDesc(args, opts))
 
-	cmdName := "kapp"
-	cmd := exec.Command(cmdName, args...)
+	cmd := exec.Command(k.kappPath, args...)
 	cmd.Stdin = opts.StdinReader
 
 	var stderr, stdout bytes.Buffer

--- a/test/e2e/order_test.go
+++ b/test/e2e/order_test.go
@@ -9,7 +9,7 @@ import (
 func TestOrder(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	name := "test-order"
 	cleanUp := func() {

--- a/test/e2e/template_test.go
+++ b/test/e2e/template_test.go
@@ -13,7 +13,7 @@ import (
 func TestTemplate(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 	kubectl := Kubectl{t, env.Namespace, logger}
 
 	depYAML := `---

--- a/test/e2e/update_replace_test.go
+++ b/test/e2e/update_replace_test.go
@@ -8,7 +8,7 @@ import (
 func TestUpdateFallbackOnReplace(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 	kubectl := Kubectl{t, env.Namespace, logger}
 
 	yaml1 := `
@@ -86,7 +86,7 @@ spec:
 func TestUpdateAlwaysReplace(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 	kubectl := Kubectl{t, env.Namespace, logger}
 
 	yaml1 := `

--- a/test/e2e/update_retry_on_conflict_test.go
+++ b/test/e2e/update_retry_on_conflict_test.go
@@ -12,7 +12,7 @@ import (
 func TestUpdateRetryOnConflict_WithoutConflict(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	yaml1 := `
 ---
@@ -106,7 +106,7 @@ spec:
 func TestUpdateRetryOnConflict_WithConflict(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	yaml1 := `
 ---
@@ -194,7 +194,7 @@ spec:
 func TestUpdateRetryOnConflict_WithConflictRebasedAway(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	yaml1 := `
 ---

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestVersion(t *testing.T) {
 	env := BuildEnv(t)
-	kapp := Kapp{t, env.Namespace, Logger{}}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
 
 	out, _ := kapp.RunWithOpts([]string{"version"}, RunOpts{NoNamespace: true})
 


### PR DESCRIPTION
This commit introduces the `KAPP_BINARY_PATH` environment varialbe so
that the path to the binary can be configured when running the end to
end suite. If not specified, `KAPP_BINARY_PATH` will default to the
`kapp` that is on the `PATH`. When running `./hack/test-all.sh`, the
`KAPP_BINARY_PATH` will be configured to the binary that is built.

Fixes #55