### PR TITLE
Coloring the result

### DIFF
--- a/vendor/github.com/fatih/color/color.go
+++ b/vendor/github.com/fatih/color/color.go
@@ -17,8 +17,9 @@ var (
 	// false or true based on the stdout's file descriptor referring to a terminal
 	// or not. This is a global option and affects all colors. For more control
 	// over each color block use the methods DisableColor() individually.
-	NoColor = os.Getenv("TERM") == "dumb" ||
-		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
+	// To force color display, set the variable FORCE_COLOR = "1"
+    	NoColor = (os.Getenv("TERM") == "dumb" ||
+    		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))) && (!(os.Getenv("FORCE_COLOR") == "1"))
 
 	// Output defines the standard output of the print functions. By default
 	// os.Stdout is used.

--- a/vendor/github.com/fatih/color/color.go
+++ b/vendor/github.com/fatih/color/color.go
@@ -18,9 +18,9 @@ var (
 	// or not. This is a global option and affects all colors. For more control
 	// over each color block use the methods DisableColor() individually.
 	// To force color display, set the variable FORCE_COLOR = "1"
-    	NoColor = (os.Getenv("TERM") == "dumb" ||
-    		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))) && (!(os.Getenv("FORCE_COLOR") == "1"))
-
+    	NoColor = (!(os.Getenv("FORCE_COLOR") == "1")) && (os.Getenv("TERM") == "dumb" ||
+		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())))
+	
 	// Output defines the standard output of the print functions. By default
 	// os.Stdout is used.
 	Output = colorable.NewColorableStdout()


### PR DESCRIPTION
This module is no longer maintained, but due to problems with coloring the result in gitlab-ci I added a fix to solve this problem. The problem concerns https://github.com/k14s/kapp/issues/84 The change has no impact on the current operation of the module. However, it allows you to force the result to be colored.