### PR TITLE
Bump version to 0.22.0

### DIFF
--- a/pkg/kapp/cmd/version.go
+++ b/pkg/kapp/cmd/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	Version = "0.21.0"
+	Version = "0.22.0"
 )
 
 type VersionOptions struct {


### PR DESCRIPTION
Just noticed the version was behind when building the most recent release. Or maybe this should be `0.22.1` or `0.23.0` to catch the next release? Whatever you'd like of course, just wanted to make the issue since I noticed it. Thanks :slightly_smiling_face: 