### PR TITLE
[KAPP-71] Watch pods in specific namespace when needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /kapp-linux-amd64
 /kapp-windows-amd64.exe
 /tmp
+
+.idea

--- a/pkg/kapp/cmd/core/strings_single_line_value.go
+++ b/pkg/kapp/cmd/core/strings_single_line_value.go
@@ -10,7 +10,9 @@ type ValueStringsSingleLine struct {
 	S []string
 }
 
-func NewValueStringsSingleLine(s []string) ValueStringsSingleLine { return ValueStringsSingleLine{S: s} }
+func NewValueStringsSingleLine(s []string) ValueStringsSingleLine {
+	return ValueStringsSingleLine{S: s}
+}
 
 func (t ValueStringsSingleLine) String() string       { return strings.Join(t.S, ", ") }
 func (t ValueStringsSingleLine) Value() uitable.Value { return t }

--- a/pkg/kapp/resources/identified_resources.go
+++ b/pkg/kapp/resources/identified_resources.go
@@ -10,10 +10,11 @@ import (
 )
 
 type IdentifiedResources struct {
-	coreClient    kubernetes.Interface
-	resourceTypes ResourceTypes
-	resources     *Resources
-	logger        logger.Logger
+	coreClient                kubernetes.Interface
+	fallbackAllowedNamespaces []string
+	resourceTypes             ResourceTypes
+	resources                 *Resources
+	logger                    logger.Logger
 }
 
 func NewIdentifiedResources(coreClient kubernetes.Interface,
@@ -22,7 +23,7 @@ func NewIdentifiedResources(coreClient kubernetes.Interface,
 
 	resources := NewResources(resourceTypes, coreClient, dynamicClient, fallbackAllowedNamespaces, logger)
 
-	return IdentifiedResources{coreClient, resourceTypes, resources, logger.NewPrefixed("IdentifiedResources")}
+	return IdentifiedResources{coreClient, fallbackAllowedNamespaces, resourceTypes, resources, logger.NewPrefixed("IdentifiedResources")}
 }
 
 func (r IdentifiedResources) Create(resource Resource) (Resource, error) {

--- a/pkg/kapp/resources/identified_resources_pods.go
+++ b/pkg/kapp/resources/identified_resources_pods.go
@@ -2,15 +2,15 @@ package resources
 
 import (
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
 func (r IdentifiedResources) PodResources(labelSelector labels.Selector) UniquePodWatcher {
-	return UniquePodWatcher{labelSelector, r.resources.fallbackAllowedNamespaces, r.coreClient}
+	return UniquePodWatcher{labelSelector, r.fallbackAllowedNamespaces, r.coreClient}
 }
 
 type PodWatcherI interface {
@@ -29,21 +29,32 @@ func (w UniquePodWatcher) Watch(podsToWatchCh chan corev1.Pod, cancelCh chan str
 	nonUniquePodsToWatchCh := make(chan corev1.Pod)
 
 	go func() {
+		// Watch Pods in all namespaces first and fallback to the
+		// fallbackAllowedNamespaces if lack of permission
 		namespace := ""
-		if len(w.fallbackAllowedNamespaces) > 0 {
-			// The '-n' flag can specify only 1 namespace, so there
-			// should be at most 1 item in fallbackAllowedNamespaces
-			namespace = w.fallbackAllowedNamespaces[0]
-		}
+		for {
+			podWatcher := NewPodWatcher(
+				w.coreClient.CoreV1().Pods(namespace),
+				metav1.ListOptions{LabelSelector: w.labelSelector.String()},
+			)
 
-		podWatcher := NewPodWatcher(
-			w.coreClient.CoreV1().Pods(namespace),
-			metav1.ListOptions{LabelSelector: w.labelSelector.String()},
-		)
-
-		err := podWatcher.Watch(nonUniquePodsToWatchCh, cancelCh)
-		if err != nil {
-			fmt.Printf("Pod watching error: %s\n", err) // TODO
+			err := podWatcher.Watch(nonUniquePodsToWatchCh, cancelCh)
+			if err == nil {
+				break
+			}
+			if errors.IsForbidden(err) && namespace == "" {
+				// The '-n' flag or default state namespace can specify only 1 namespace, so there
+				// should be at most 1 item in fallbackAllowedNamespaces
+				if len(w.fallbackAllowedNamespaces) > 0 {
+					namespace = w.fallbackAllowedNamespaces[0]
+					if namespace == "" {
+						break
+					}
+				}
+			} else {
+				fmt.Printf("Pod watching error: %s\n", err) // TODO
+				break
+			}
 		}
 
 		close(nonUniquePodsToWatchCh)


### PR DESCRIPTION
When a namespace-scoped RBAC user is used by kubectl, and this
user doesn't have privilege to watch pods in all namespaces,
we should only watch the namespace specified by '-n' flag or
default to the namespace specified in kubeconfig.

Manually tested on Mac OS and the error msg is gone:
`./kapp deploy -a myapp -f examples/gitops/guestbook/`

Close https://github.com/k14s/kapp/issues/71