### PR TITLE
Kapp logs option to tail only specific containers in pod

### DIFF
--- a/pkg/kapp/cmd/app/logs_flags.go
+++ b/pkg/kapp/cmd/app/logs_flags.go
@@ -8,11 +8,11 @@ import (
 )
 
 type LogsFlags struct {
-	Follow        bool
-	Lines         int64
-	ContainerName []string
-	ContainerTag  bool
-	PodName       string
+	Follow         bool
+	Lines          int64
+	ContainerNames []string
+	ContainerTag   bool
+	PodName        string
 }
 
 func (s *LogsFlags) Set(cmd *cobra.Command) {
@@ -20,7 +20,7 @@ func (s *LogsFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(&s.Lines, "lines", 10, "Limit to number of lines (use -1 to remove limit)")
 	cmd.Flags().BoolVar(&s.ContainerTag, "container-tag", true, "Include container tag")
 	cmd.Flags().StringVarP(&s.PodName, "pod-name", "m", "", "Set pod name to filter logs (% acts as wildcard, e.g. 'app%')")
-	cmd.Flags().StringSliceVarP(&s.ContainerName, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma")
+	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma")
 }
 
 func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {
@@ -29,7 +29,7 @@ func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {
 			"Expected --lines to be greater than zero since --follow is not specified")
 	}
 
-	opts := ctllogs.PodLogOpts{Follow: s.Follow, ContainerName: s.ContainerName, ContainerTag: s.ContainerTag}
+	opts := ctllogs.PodLogOpts{Follow: s.Follow, ContainerNames: s.ContainerNames, ContainerTag: s.ContainerTag}
 
 	if s.Lines >= 0 {
 		opts.Lines = &s.Lines

--- a/pkg/kapp/cmd/app/logs_flags.go
+++ b/pkg/kapp/cmd/app/logs_flags.go
@@ -8,10 +8,11 @@ import (
 )
 
 type LogsFlags struct {
-	Follow       bool
-	Lines        int64
-	ContainerTag bool
-	PodName      string
+	Follow         bool
+	Lines          int64
+	ContainerNames []string
+	ContainerTag   bool
+	PodName        string
 }
 
 func (s *LogsFlags) Set(cmd *cobra.Command) {
@@ -19,6 +20,7 @@ func (s *LogsFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(&s.Lines, "lines", 10, "Limit to number of lines (use -1 to remove limit)")
 	cmd.Flags().BoolVar(&s.ContainerTag, "container-tag", true, "Include container tag")
 	cmd.Flags().StringVarP(&s.PodName, "pod-name", "m", "", "Set pod name to filter logs (% acts as wildcard, e.g. 'app%')")
+	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-names", "c", []string{}, "Set container names to filter logs in the pod, separated by comma")
 }
 
 func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {
@@ -31,6 +33,10 @@ func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {
 
 	if s.Lines >= 0 {
 		opts.Lines = &s.Lines
+	}
+
+	if len(s.ContainerNames) > 0 {
+		opts.ContainerNames = s.ContainerNames
 	}
 
 	return opts, nil

--- a/pkg/kapp/cmd/app/logs_flags.go
+++ b/pkg/kapp/cmd/app/logs_flags.go
@@ -8,11 +8,11 @@ import (
 )
 
 type LogsFlags struct {
-	Follow         bool
-	Lines          int64
-	ContainerNames []string
-	ContainerTag   bool
-	PodName        string
+	Follow        bool
+	Lines         int64
+	ContainerName []string
+	ContainerTag  bool
+	PodName       string
 }
 
 func (s *LogsFlags) Set(cmd *cobra.Command) {
@@ -20,7 +20,7 @@ func (s *LogsFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(&s.Lines, "lines", 10, "Limit to number of lines (use -1 to remove limit)")
 	cmd.Flags().BoolVar(&s.ContainerTag, "container-tag", true, "Include container tag")
 	cmd.Flags().StringVarP(&s.PodName, "pod-name", "m", "", "Set pod name to filter logs (% acts as wildcard, e.g. 'app%')")
-	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-names", "c", []string{}, "Set container names to filter logs in the pod, separated by comma")
+	cmd.Flags().StringSliceVarP(&s.ContainerName, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma")
 }
 
 func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {
@@ -29,14 +29,10 @@ func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {
 			"Expected --lines to be greater than zero since --follow is not specified")
 	}
 
-	opts := ctllogs.PodLogOpts{Follow: s.Follow, ContainerTag: s.ContainerTag}
+	opts := ctllogs.PodLogOpts{Follow: s.Follow, ContainerName: s.ContainerName, ContainerTag: s.ContainerTag}
 
 	if s.Lines >= 0 {
 		opts.Lines = &s.Lines
-	}
-
-	if len(s.ContainerNames) > 0 {
-		opts.ContainerNames = s.ContainerNames
 	}
 
 	return opts, nil

--- a/pkg/kapp/logs/pod_log.go
+++ b/pkg/kapp/logs/pod_log.go
@@ -9,11 +9,11 @@ import (
 )
 
 type PodLogOpts struct {
-	Follow         bool
-	Lines          *int64
-	ContainerNames []string
-	ContainerTag   bool
-	LinePrefix     string
+	Follow        bool
+	Lines         *int64
+	ContainerName []string
+	ContainerTag  bool
+	LinePrefix    string
 }
 
 type PodLog struct {
@@ -42,10 +42,8 @@ func (l PodLog) TailAll(ui ui.UI, cancelCh chan struct{}) error {
 
 	for _, cont := range l.pod.Spec.InitContainers {
 		if !(podInTerminalState && l.isWaitingContainer(cont, l.pod.Status.InitContainerStatuses)) {
-			if len(l.opts.ContainerNames) > 0 {
-				if l.isContainerInSlice(cont, l.opts.ContainerNames) {
-					conts = append(conts, cont)
-				}
+			if l.isWatchingContainer(cont, l.opts.ContainerName) {
+				conts = append(conts, cont)
 				continue
 			}
 			conts = append(conts, cont)
@@ -54,10 +52,8 @@ func (l PodLog) TailAll(ui ui.UI, cancelCh chan struct{}) error {
 
 	for _, cont := range l.pod.Spec.Containers {
 		if !(podInTerminalState && l.isWaitingContainer(cont, l.pod.Status.ContainerStatuses)) {
-			if len(l.opts.ContainerNames) > 0 {
-				if l.isContainerInSlice(cont, l.opts.ContainerNames) {
-					conts = append(conts, cont)
-				}
+			if l.isWatchingContainer(cont, l.opts.ContainerName) {
+				conts = append(conts, cont)
 				continue
 			}
 			conts = append(conts, cont)
@@ -90,7 +86,10 @@ func (l PodLog) isWaitingContainer(cont corev1.Container, statuses []corev1.Cont
 	return false
 }
 
-func (l PodLog) isContainerInSlice(cont corev1.Container, containers []string) bool {
+func (l PodLog) isWatchingContainer(cont corev1.Container, containers []string) bool {
+	if len(containers) == 0 {
+		return true
+	}
 	for _, n := range containers {
 		if cont.Name == n {
 			return true

--- a/pkg/kapp/logs/pod_log.go
+++ b/pkg/kapp/logs/pod_log.go
@@ -44,9 +44,7 @@ func (l PodLog) TailAll(ui ui.UI, cancelCh chan struct{}) error {
 		if !(podInTerminalState && l.isWaitingContainer(cont, l.pod.Status.InitContainerStatuses)) {
 			if l.isWatchingContainer(cont, l.opts.ContainerName) {
 				conts = append(conts, cont)
-				continue
 			}
-			conts = append(conts, cont)
 		}
 	}
 
@@ -54,9 +52,7 @@ func (l PodLog) TailAll(ui ui.UI, cancelCh chan struct{}) error {
 		if !(podInTerminalState && l.isWaitingContainer(cont, l.pod.Status.ContainerStatuses)) {
 			if l.isWatchingContainer(cont, l.opts.ContainerName) {
 				conts = append(conts, cont)
-				continue
 			}
-			conts = append(conts, cont)
 		}
 	}
 

--- a/pkg/kapp/logs/pod_log.go
+++ b/pkg/kapp/logs/pod_log.go
@@ -9,11 +9,11 @@ import (
 )
 
 type PodLogOpts struct {
-	Follow        bool
-	Lines         *int64
-	ContainerName []string
-	ContainerTag  bool
-	LinePrefix    string
+	Follow         bool
+	Lines          *int64
+	ContainerNames []string
+	ContainerTag   bool
+	LinePrefix     string
 }
 
 type PodLog struct {
@@ -42,7 +42,7 @@ func (l PodLog) TailAll(ui ui.UI, cancelCh chan struct{}) error {
 
 	for _, cont := range l.pod.Spec.InitContainers {
 		if !(podInTerminalState && l.isWaitingContainer(cont, l.pod.Status.InitContainerStatuses)) {
-			if l.isWatchingContainer(cont, l.opts.ContainerName) {
+			if l.isWatchingContainer(cont, l.opts.ContainerNames) {
 				conts = append(conts, cont)
 			}
 		}
@@ -50,7 +50,7 @@ func (l PodLog) TailAll(ui ui.UI, cancelCh chan struct{}) error {
 
 	for _, cont := range l.pod.Spec.Containers {
 		if !(podInTerminalState && l.isWaitingContainer(cont, l.pod.Status.ContainerStatuses)) {
-			if l.isWatchingContainer(cont, l.opts.ContainerName) {
+			if l.isWatchingContainer(cont, l.opts.ContainerNames) {
 				conts = append(conts, cont)
 			}
 		}


### PR DESCRIPTION
Adding initial support for specific container logs in kapp logs command output.

Related to #103.