### PR TITLE
kapp logs: add support for wildcard filtering in container names

### DIFF
--- a/pkg/kapp/cmd/app/logs_flags.go
+++ b/pkg/kapp/cmd/app/logs_flags.go
@@ -20,7 +20,7 @@ func (s *LogsFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(&s.Lines, "lines", 10, "Limit to number of lines (use -1 to remove limit)")
 	cmd.Flags().BoolVar(&s.ContainerTag, "container-tag", true, "Include container tag")
 	cmd.Flags().StringVarP(&s.PodName, "pod-name", "m", "", "Set pod name to filter logs (% acts as wildcard, e.g. 'app%')")
-	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma")
+	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma (% acts as wildcard, e.g. 'app%')")
 }
 
 func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {

--- a/pkg/kapp/logs/pod_log.go
+++ b/pkg/kapp/logs/pod_log.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/k14s/kapp/pkg/kapp/matcher"
 	corev1 "k8s.io/api/core/v1"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -87,7 +88,7 @@ func (l PodLog) isWatchingContainer(cont corev1.Container, containers []string) 
 		return true
 	}
 	for _, n := range containers {
-		if cont.Name == n {
+		if matcher.NewStringMatcher(n).Matches(cont.Name) {
 			return true
 		}
 	}


### PR DESCRIPTION
Add support for wildcard filtering in container names in kapp logs command output.

Related to #103.