### PR TITLE
Deploy per container logs

### DIFF
--- a/docs/apply.md
+++ b/docs/apply.md
@@ -44,6 +44,10 @@ Related: [ownership label rules](config.md) and [label scoping rules](config.md)
 
     Possible values: `` (default). Especially useful when added to Jobs. For example, see [examples/resource-ordering/sync-check.yml](../examples/resource-ordering/sync-check.yml)
 
+- `kapp.k14s.io/deploy-logs-container-names` annotation indicates which Containers' log output to show during deploy
+
+    Possible values: `` (default), 'containerName1', 'containerName1,containerName2'
+	
 ### Controlling apply via deploy flags
 
 - `--apply-ignored=bool` explicitly applies ignored changes; this is useful in cases when controllers lose track of some resources instead of for example deleting them

--- a/pkg/kapp/cmd/app/logs.go
+++ b/pkg/kapp/cmd/app/logs.go
@@ -71,7 +71,14 @@ func (o *LogsOptions) Run() error {
 		supportObjs.IdentifiedResources.PodResources(labelSelector),
 	}
 
-	logsView := ctllogs.NewView(logOpts, podWatcher, supportObjs.CoreClient, o.ui)
+	contFilter := func(pod corev1.Pod) []string {
+		if len(o.LogsFlags.ContainerNames) > 0 {
+			return o.LogsFlags.ContainerNames
+		}
+		return nil
+	}
+
+	logsView := ctllogs.NewView(logOpts, podWatcher, contFilter, supportObjs.CoreClient, o.ui)
 
 	return logsView.Show(make(chan struct{}))
 }

--- a/pkg/kapp/cmd/app/logs.go
+++ b/pkg/kapp/cmd/app/logs.go
@@ -72,10 +72,7 @@ func (o *LogsOptions) Run() error {
 	}
 
 	contFilter := func(pod corev1.Pod) []string {
-		if len(o.LogsFlags.ContainerNames) > 0 {
-			return o.LogsFlags.ContainerNames
-		}
-		return nil
+		return o.LogsFlags.ContainerNames
 	}
 
 	logsView := ctllogs.NewView(logOpts, podWatcher, contFilter, supportObjs.CoreClient, o.ui)

--- a/pkg/kapp/cmd/app/logs_flags.go
+++ b/pkg/kapp/cmd/app/logs_flags.go
@@ -20,7 +20,7 @@ func (s *LogsFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(&s.Lines, "lines", 10, "Limit to number of lines (use -1 to remove limit)")
 	cmd.Flags().BoolVar(&s.ContainerTag, "container-tag", true, "Include container tag")
 	cmd.Flags().StringVarP(&s.PodName, "pod-name", "m", "", "Set pod name to filter logs (% acts as wildcard, e.g. 'app%')")
-	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma")
+	cmd.Flags().StringSliceVarP(&s.ContainerNames, "container-name", "c", nil, "Set container names to filter logs in the pod, separated by comma (% acts as wildcard, e.g. 'app%')")
 }
 
 func (s *LogsFlags) PodLogOpts() (ctllogs.PodLogOpts, error) {

--- a/pkg/kapp/logs/pod_log.go
+++ b/pkg/kapp/logs/pod_log.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/k14s/kapp/pkg/kapp/matcher"
 	corev1 "k8s.io/api/core/v1"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -87,7 +88,7 @@ func (l PodLog) isWatchingContainer(cont corev1.Container, containers []string) 
 		return true
 	}
 	for _, n := range containers {
-		if cont.Name == n {
+		if matcher.NewStringMatcher(n).Matches(cont.Name) {
 			return true
 		}
 	}

--- a/pkg/kapp/logs/view.go
+++ b/pkg/kapp/logs/view.go
@@ -14,19 +14,21 @@ type PodWatcher interface {
 }
 
 type View struct {
-	tailOpts   PodLogOpts
-	podWatcher PodWatcher
-	coreClient kubernetes.Interface
-	ui         ui.UI
+	tailOpts       PodLogOpts
+	podWatcher     PodWatcher
+	contFilterFunc func(pod corev1.Pod) []string
+	coreClient     kubernetes.Interface
+	ui             ui.UI
 }
 
 func NewView(
 	tailOpts PodLogOpts,
 	podWatcher PodWatcher,
+	contFilterFunc func(pod corev1.Pod) []string,
 	coreClient kubernetes.Interface,
 	ui ui.UI,
 ) View {
-	return View{tailOpts, podWatcher, coreClient, ui}
+	return View{tailOpts, podWatcher, contFilterFunc, coreClient, ui}
 }
 
 func (v View) Show(cancelCh chan struct{}) error {
@@ -65,6 +67,8 @@ func (v View) Show(cancelCh chan struct{}) error {
 			tagFunc := func(cont corev1.Container) string {
 				return fmt.Sprintf("%s > %s", pod.Name, cont.Name)
 			}
+
+			v.tailOpts.ContainerNames = v.contFilterFunc(pod)
 
 			err := NewPodLog(pod, podsClient, tagFunc, v.tailOpts).TailAll(v.ui, cancelPodTailCh)
 			if err != nil {

--- a/pkg/kapp/logs/view.go
+++ b/pkg/kapp/logs/view.go
@@ -68,9 +68,10 @@ func (v View) Show(cancelCh chan struct{}) error {
 				return fmt.Sprintf("%s > %s", pod.Name, cont.Name)
 			}
 
-			v.tailOpts.ContainerNames = v.contFilterFunc(pod)
+			tailOpts := v.tailOpts
+			tailOpts.ContainerNames = v.contFilterFunc(pod)
 
-			err := NewPodLog(pod, podsClient, tagFunc, v.tailOpts).TailAll(v.ui, cancelPodTailCh)
+			err := NewPodLog(pod, podsClient, tagFunc, tailOpts).TailAll(v.ui, cancelPodTailCh)
 			if err != nil {
 				v.ui.BeginLinef("Pod logs tailing error: %s\n", err)
 			}


### PR DESCRIPTION
Add support for wildcard filtering for container names in kapp logs cli command.
Add support for new annotations kapp.k14s.io/deploy-logs-container-names: "name1,name2..." for kapp deploy command to filter log output by container names.

Related #103 