### PR TITLE
Update Secret and ConfigMap reference paths in default rules

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -244,6 +244,8 @@ templateRules:
       resourceMatchers: *withPodTemplate
     - path: [spec, template, spec, initContainers, {allIndexes: true}, envFrom, {allIndexes: true}, secretRef]
       resourceMatchers: *withPodTemplate
+    - path: [spec, template, spec, imagePullSecrets, {allIndexes: true}]
+      resourceMatchers: *withPodTemplate
     - path: [spec, template, spec, volumes, {allIndexes: true}, secret]
       resourceMatchers: *withPodTemplate
       nameKey: secretName
@@ -253,6 +255,12 @@ templateRules:
       resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}
       nameKey: secretName
+    - path: [spec, imagePullSecrets, {allIndexes: true}]
+      resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}
+    - path: [imagePullSecrets, {allIndexes: true}]
+      resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: v1, kind: ServiceAccount}
     - path: [secrets, {allIndexes: true}]
       resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: v1, kind: ServiceAccount}

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -253,6 +253,9 @@ templateRules:
       resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}
       nameKey: secretName
+    - path: [secrets, {allIndexes: true}]
+      resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: v1, kind: ServiceAccount}
 
 changeGroupBindings:
 - name: change-groups.kapp.k14s.io/crds

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -224,6 +224,8 @@ templateRules:
       resourceMatchers: *withPodTemplate
     - path: [spec, template, spec, initContainers, {allIndexes: true}, envFrom, {allIndexes: true}, configMapRef]
       resourceMatchers: *withPodTemplate
+    - path: [spec, template, spec, volumes, {allIndexes: true}, projected, sources, {allIndexes: true}, configMap]
+      resourceMatchers: *withPodTemplate
     - path: [spec, template, spec, volumes, {allIndexes: true}, configMap]
       resourceMatchers: *withPodTemplate
     - path: [spec, volumes, {allIndexes: true}, configMap]
@@ -245,6 +247,8 @@ templateRules:
     - path: [spec, template, spec, volumes, {allIndexes: true}, secret]
       resourceMatchers: *withPodTemplate
       nameKey: secretName
+    - path: [spec, template, spec, volumes, {allIndexes: true}, projected, sources, {allIndexes: true}, secret]
+      resourceMatchers: *withPodTemplate
     - path: [spec, volumes, {allIndexes: true}, secret]
       resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}


### PR DESCRIPTION
## Context
Kapp versioned Secrets and ConfigMaps are not updated within [projected volumes](https://kubernetes.io/docs/concepts/storage/volumes/#projected) or ServiceAccounts by default. Similarly, Secrets of type ImagePullSecrets can have a different key/path in Pod and ServiceAccount specs.

## Proposed Change
Update the default template rules to include object references to the above resource paths so that versioned Secrets and ConfigMaps are updated by default.

## Open Question
Are ImagePullSecrets paths a necessary default directly on Pod specs? I don't know how prevalent their use is.

## Validation
I validated the first two commits by deploying cf-for-k8s with the kapp versioned annotation on all non-sds secrets and kapp was able to deploy successfully with the app functional. I didn't have any instances of nested imagePullSecrets in the deployment I happened to use, so the last commit is just based on the api definitions.