### PR TITLE
feat: custom waiting via kapp config

### DIFF
--- a/pkg/kapp/clusterapply/converged_resource_factory.go
+++ b/pkg/kapp/clusterapply/converged_resource_factory.go
@@ -71,5 +71,7 @@ func (f ConvergedResourceFactory) New(res ctlres.Resource,
 		},
 	}
 
-	return NewConvergedResource(res, associatedRsFunc, specificResFactories)
+	waitingRuleMod := ctlres.GetWaitingRule(res)
+
+	return NewConvergedResource(res, associatedRsFunc, specificResFactories, waitingRuleMod)
 }

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -228,9 +228,8 @@ func (o *DeployOptions) newResources(
 	if err != nil {
 		return nil, ctlconf.Conf{}, nil, err
 	}
-
 	err = labeledResources.Prepare(newResources, conf.OwnershipLabelMods(),
-		conf.LabelScopingMods(), conf.AdditionalLabels())
+		conf.LabelScopingMods(), conf.AdditionalLabels(), conf.WaitRuleMods())
 	if err != nil {
 		return nil, ctlconf.Conf{}, nil, err
 	}

--- a/pkg/kapp/config/config.go
+++ b/pkg/kapp/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MinimumRequiredVersion string `json:"minimumRequiredVersion,omitempty"`
 
 	RebaseRules         []RebaseRule
+	WaitingRules        []WaitingRule
 	OwnershipLabelRules []OwnershipLabelRule
 	LabelScopingRules   []LabelScopingRule
 	TemplateRules       []TemplateRule
@@ -33,6 +34,13 @@ type Config struct {
 	// TODO validations
 	ChangeGroupBindings []ChangeGroupBinding
 	ChangeRuleBindings  []ChangeRuleBinding
+}
+
+type WaitingRule struct {
+	SupportsObservedGeneration bool             `json:"supportsObservedGeneration"`
+	SuccessfulConditions       []string         `json:"successfulConditions"`
+	FailureConditions          []string         `json:"failureConditions"`
+	ResourceMatchers           ResourceMatchers `json:"resourceMatchers"`
 }
 
 type RebaseRule struct {
@@ -150,7 +158,6 @@ func NewConfigFromResource(res ctlres.Resource) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-
 	var config Config
 
 	err = yaml.Unmarshal(bs, &config)

--- a/pkg/kapp/resources/labeled_resources.go
+++ b/pkg/kapp/resources/labeled_resources.go
@@ -28,8 +28,9 @@ func NewLabeledResources(labelSelector labels.Selector,
 	return &LabeledResources{labelSelector, identifiedResources, logger.NewPrefixed("LabeledResources")}
 }
 
+// Modifies passed resources for labels and ownership
 func (a *LabeledResources) Prepare(resources []Resource, olmFunc OwnershipLabelModsFunc,
-	lsmFunc LabelScopingModsFunc, additionalLabels map[string]string) error {
+	lsmFunc LabelScopingModsFunc, additionalLabels map[string]string, waitRuleMods []WaitingRuleMod) error {
 
 	defer a.logger.DebugFunc("Prepare").Finish()
 

--- a/pkg/kapp/resources/mod_waiting_rules.go
+++ b/pkg/kapp/resources/mod_waiting_rules.go
@@ -1,0 +1,30 @@
+package resources
+
+var globalWaitingRules []WaitingRuleMod
+
+func SetGlobalWaitingRules(rules []WaitingRuleMod) {
+	globalWaitingRules = rules
+}
+
+type WaitingRuleMod struct {
+	SupportsObservedGeneration bool              `json:"supportsObservedGeneration"`
+	SuccessfulConditions       []string          `json:"successfulConditions"`
+	FailureConditions          []string          `json:"failureConditions"`
+	ResourceMatchers           []ResourceMatcher `json:"resourceMatchers"`
+}
+
+// Find waiting rule for specified resource
+func GetWaitingRule(res Resource) WaitingRuleMod {
+	rules := globalWaitingRules
+	mod := WaitingRuleMod{}
+	for _, rule := range rules {
+		for _, matcher := range rule.ResourceMatchers {
+			if matcher.Matches(res) {
+				mod.SupportsObservedGeneration = rule.SupportsObservedGeneration
+				mod.SuccessfulConditions = append(mod.SuccessfulConditions, rule.SuccessfulConditions...)
+				mod.FailureConditions = append(mod.FailureConditions, rule.FailureConditions...)
+			}
+		}
+	}
+	return mod
+}


### PR DESCRIPTION
Adds support for waiting for custom resources via kapp Config.

Supported config syntax:
```yaml
apiVersion: kapp.k14s.io/v1alpha1
kind: Config
ownershipLabelRules:
  - path: [spec, labels]
    resourceMatchers:
      - apiVersionKindMatcher:
          { apiVersion: openfaas.com/v1alpha2, kind: Function }
waitingRules:
  - supportsObservedGeneration: true
    successfulConditions: ['Ready']
    failureConditions: ['Failed']
    resourceMatchers:
      - apiVersionKindMatcher:
          { apiVersion: openfaas.com/v1alpha2, kind: Function }
```