### PR TITLE
Improve apply retry

### DIFF
--- a/pkg/kapp/clusterapply/cluster_change.go
+++ b/pkg/kapp/clusterapply/cluster_change.go
@@ -143,7 +143,7 @@ func (c *ClusterChange) Apply() (bool, []string, error) {
 		return false, descMsgs, err
 	}
 
-	retryable := err != nil && ctlres.IsRetriableWebhookError(err)
+	retryable := err != nil && ctlres.IsResourceChangeBlockedErr(err)
 	if retryable {
 		descMsgs = append(descMsgs, uiWaitMsgPrefix+"Retryable error: "+err.Error())
 	}

--- a/pkg/kapp/clusterapply/cluster_change.go
+++ b/pkg/kapp/clusterapply/cluster_change.go
@@ -143,7 +143,7 @@ func (c *ClusterChange) Apply() (bool, []string, error) {
 		return false, descMsgs, err
 	}
 
-	retryable := err != nil && ctlres.IsRetryableErr(err)
+	retryable := err != nil && ctlres.IsRetriableWebhookError(err)
 	if retryable {
 		descMsgs = append(descMsgs, uiWaitMsgPrefix+"Retryable error: "+err.Error())
 	}

--- a/pkg/kapp/util/retry.go
+++ b/pkg/kapp/util/retry.go
@@ -29,28 +29,3 @@ func Retry(interval, timeout time.Duration, condFunc wait.ConditionFunc) error {
 
 	return nil
 }
-
-// Copied from newer version of "k8s.io/client-go/util/retry" OnError
-
-// RetryOnError allows the caller to retry fn in case the error returned by fn is retriable
-// according to the provided function. backoff defines the maximum retries and the wait
-// interval between two retries.
-func RetryOnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
-	var lastErr error
-	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		err := fn()
-		switch {
-		case err == nil:
-			return true, nil
-		case retriable(err):
-			lastErr = err
-			return false, nil
-		default:
-			return false, err
-		}
-	})
-	if err == wait.ErrWaitTimeout {
-		err = lastErr
-	}
-	return err
-}

--- a/pkg/kapp/util/retry.go
+++ b/pkg/kapp/util/retry.go
@@ -29,3 +29,28 @@ func Retry(interval, timeout time.Duration, condFunc wait.ConditionFunc) error {
 
 	return nil
 }
+
+// Copied from newer version of "k8s.io/client-go/util/retry" OnError
+
+// RetryOnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func RetryOnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}


### PR DESCRIPTION
This PR is mostly related to issues #82 and #87.

* `util.Retry` was replaced by `util.RetryOnError` which is a copy of `k8s.io/client-go/util/retry.OnError`. It seems to be the standard way to do retries with newer versions of the k8s client library.
* The two errors `http2.GoAwayError` and `errors.StatusError` with `err.ErrStatus.Reason == metav1.StatusReasonServiceUnavailable` are automatically retried.
* List functions are also retried now