### PR TITLE
Use the correct path for default config's CustomResourceDefinition rule.

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -114,6 +114,11 @@ rebaseRules:
   sources: [new, existing]
   resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: apiextensions.k8s.io/v1beta1, kind: CustomResourceDefinition}
+
+- path: [spec, conversion, webhook, clientConfig, caBundle]
+  type: copy
+  sources: [new, existing]
+  resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: apiextensions.k8s.io/v1, kind: CustomResourceDefinition}
 
 - path: [spec, nodeName]


### PR DESCRIPTION
The spec for v1 and v1beta1 differs.

v1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#customresourcedefinition-v1-apiextensions-k8s-io
v1beta1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#customresourcedefinition-v1beta1-apiextensions-k8s-io