### PR TITLE
Adding golint and goheader linters via golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.34
+          args: -v --max-same-issues 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  enable:
+    - goheader
+    - golint
+  disable-all: true
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    template-path: code-header-template.txt

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x -u
+
+./hack/build.sh
+./hack/linter.sh

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+golangci-lint cache clean
+golangci-lint run --max-same-issues 0 --tests=false

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -2,4 +2,4 @@
 set -e
 
 golangci-lint cache clean
-golangci-lint run --max-same-issues 0 --tests=false
+golangci-lint run --max-same-issues 0

--- a/pkg/kapp/app/app_meta.go
+++ b/pkg/kapp/app/app_meta.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type AppMeta struct {
+type Meta struct {
 	LabelKey   string `json:"labelKey"`
 	LabelValue string `json:"labelValue"`
 
@@ -20,18 +20,18 @@ type AppMeta struct {
 	UsedGVs []schema.GroupVersion `json:"usedGVs,omitempty"`
 }
 
-func NewAppMetaFromData(data map[string]string) (AppMeta, error) {
-	var meta AppMeta
+func NewAppMetaFromData(data map[string]string) (Meta, error) {
+	var meta Meta
 
 	err := json.Unmarshal([]byte(data["spec"]), &meta)
 	if err != nil {
-		return AppMeta{}, fmt.Errorf("Parsing app metadata: %s", err)
+		return Meta{}, fmt.Errorf("Parsing app metadata: %s", err)
 	}
 
 	return meta, nil
 }
 
-func (m AppMeta) AsString() string {
+func (m Meta) AsString() string {
 	bytes, err := json.Marshal(m)
 	if err != nil {
 		panic(fmt.Sprintf("Encoding app meta: %s", err))
@@ -40,10 +40,10 @@ func (m AppMeta) AsString() string {
 	return string(bytes)
 }
 
-func (m AppMeta) AsData() map[string]string {
+func (m Meta) AsData() map[string]string {
 	return map[string]string{"spec": m.AsString()}
 }
 
-func (m AppMeta) Labels() map[string]string {
+func (m Meta) Labels() map[string]string {
 	return map[string]string{m.LabelKey: m.LabelValue}
 }

--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -12,7 +12,7 @@ type App interface {
 	Name() string
 	Namespace() string
 	Description() string
-	Meta() (AppMeta, error)
+	Meta() (Meta, error)
 
 	LabelSelector() (labels.Selector, error)
 	UsedGVs() ([]schema.GroupVersion, error)

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -67,7 +67,7 @@ func (a *LabeledApp) Delete() error {
 
 func (a *LabeledApp) Rename(_ string) error { return fmt.Errorf("Not supported") }
 
-func (a *LabeledApp) Meta() (AppMeta, error) { return AppMeta{}, nil }
+func (a *LabeledApp) Meta() (Meta, error) { return Meta{}, nil }
 
 func (a *LabeledApp) Changes() ([]Change, error)             { return nil, nil }
 func (a *LabeledApp) LastChange() (Change, error)            { return nil, nil }

--- a/pkg/kapp/clusterapply/changes_view.go
+++ b/pkg/kapp/clusterapply/changes_view.go
@@ -223,8 +223,8 @@ func NewChangesCountsView() *ChangesCountsView {
 }
 
 func (v *ChangesCountsView) Add(applyOp ClusterChangeApplyOp, waitOp ClusterChangeWaitOp) {
-	v.applyOps[applyOp] += 1
-	v.waitOps[waitOp] += 1
+	v.applyOps[applyOp]++
+	v.waitOps[waitOp]++
 }
 
 func (v *ChangesCountsView) Strings(table bool) []string {

--- a/pkg/kapp/clusterapply/converged_resource.go
+++ b/pkg/kapp/clusterapply/converged_resource.go
@@ -63,12 +63,11 @@ func (c ConvergedResource) IsDoneApplying() (ctlresm.DoneApplyState, []string, e
 			return ctlresm.DoneApplyState{Done: true}, descMsgs,
 				fmt.Errorf("Expected annotation '%s' on resource '%s' to have value ''",
 					disableAssociatedResourcesWaitingAnnKey, c.res.Description())
-		} else {
-			if convergedResState != nil {
-				return *convergedResState, descMsgs, nil
-			}
-			return ctlresm.DoneApplyState{Done: true, Successful: true}, descMsgs, nil
 		}
+		if convergedResState != nil {
+			return *convergedResState, descMsgs, nil
+		}
+		return ctlresm.DoneApplyState{Done: true, Successful: true}, descMsgs, nil
 	}
 
 	associatedRsStates := []ctlresm.DoneApplyState{}

--- a/pkg/kapp/clusterapply/converged_resource_factory.go
+++ b/pkg/kapp/clusterapply/converged_resource_factory.go
@@ -41,7 +41,7 @@ func (f ConvergedResourceFactory) New(res ctlres.Resource,
 			return ctlresm.NewCustomWaitingResource(res, f.waitRules), nil
 		},
 		func(res ctlres.Resource, _ []ctlres.Resource) (SpecificResource, []ctlres.ResourceRef) {
-			return ctlresm.NewApiExtensionsVxCRD(res), nil
+			return ctlresm.NewAPIExtensionsVxCRD(res), nil
 		},
 		func(res ctlres.Resource, _ []ctlres.Resource) (SpecificResource, []ctlres.ResourceRef) {
 			return ctlresm.NewAPIRegistrationV1APIService(res, f.opts.IgnoreFailingAPIServices), nil

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -85,7 +85,7 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 				return nil, fmt.Errorf("%s: Errored: %s", desc, err)
 			}
 			if state.Done {
-				c.numWaited += 1
+				c.numWaited++
 			}
 
 			switch {

--- a/pkg/kapp/cmd/app/app_flags.go
+++ b/pkg/kapp/cmd/app/app_flags.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type AppFlags struct {
+type Flags struct {
 	NamespaceFlags cmdcore.NamespaceFlags
 	Name           string
 }
 
-func (s *AppFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
+func (s *Flags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
 	s.NamespaceFlags.Set(cmd, flagsFactory)
 
 	cmd.Flags().StringVarP(&s.Name, "app", "a", "", "Set app name (or label selector) (format: name, label:key=val, !key)")

--- a/pkg/kapp/cmd/app/delete.go
+++ b/pkg/kapp/cmd/app/delete.go
@@ -23,7 +23,7 @@ type DeleteOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags            AppFlags
+	AppFlags            Flags
 	DiffFlags           cmdtools.DiffFlags
 	ResourceFilterFlags cmdtools.ResourceFilterFlags
 	ApplyFlags          ApplyFlags
@@ -54,7 +54,7 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 func (o *DeleteOptions) Run() error {
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
-	app, supportObjs, err := AppFactory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
+	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (o *DeleteOptions) Run() error {
 }
 
 func (o *DeleteOptions) existingResources(app ctlapp.App,
-	supportObjs AppFactorySupportObjs) ([]ctlres.Resource, bool, error) {
+	supportObjs FactorySupportObjs) ([]ctlres.Resource, bool, error) {
 
 	labelSelector, err := app.LabelSelector()
 	if err != nil {
@@ -169,7 +169,7 @@ func (o *DeleteOptions) existingResources(app ctlapp.App,
 }
 
 func (o *DeleteOptions) calculateAndPresentChanges(existingResources []ctlres.Resource, conf ctlconf.Conf,
-	supportObjs AppFactorySupportObjs) (ctlcap.ClusterChangeSet, *ctldgraph.ChangeGraph, bool, error) {
+	supportObjs FactorySupportObjs) (ctlcap.ClusterChangeSet, *ctldgraph.ChangeGraph, bool, error) {
 
 	var clusterChangeSet ctlcap.ClusterChangeSet
 

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -32,7 +32,7 @@ type DeployOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags            AppFlags
+	AppFlags            Flags
 	FileFlags           cmdtools.FileFlags
 	DiffFlags           cmdtools.DiffFlags
 	ResourceFilterFlags cmdtools.ResourceFilterFlags
@@ -85,7 +85,7 @@ func NewDeployCmd(o *DeployOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 func (o *DeployOptions) Run() error {
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
-	app, supportObjs, err := AppFactory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
+	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (o *DeployOptions) existingResources(newResources []ctlres.Resource,
 }
 
 func (o *DeployOptions) calculateAndPresentChanges(existingResources,
-	newResources []ctlres.Resource, conf ctlconf.Conf, supportObjs AppFactorySupportObjs) (
+	newResources []ctlres.Resource, conf ctlconf.Conf, supportObjs FactorySupportObjs) (
 	ctlcap.ClusterChangeSet, *ctldgraph.ChangeGraph, bool, string, error) {
 
 	var clusterChangeSet ctlcap.ClusterChangeSet

--- a/pkg/kapp/cmd/app/factory.go
+++ b/pkg/kapp/cmd/app/factory.go
@@ -11,24 +11,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type AppFactorySupportObjs struct {
+type FactorySupportObjs struct {
 	CoreClient          kubernetes.Interface
 	ResourceTypes       *ctlres.ResourceTypesImpl
 	IdentifiedResources ctlres.IdentifiedResources
 	Apps                ctlapp.Apps
 }
 
-func AppFactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFlags,
-	resTypesFlags ResourceTypesFlags, logger logger.Logger) (AppFactorySupportObjs, error) {
+func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFlags,
+	resTypesFlags ResourceTypesFlags, logger logger.Logger) (FactorySupportObjs, error) {
 
 	coreClient, err := depsFactory.CoreClient()
 	if err != nil {
-		return AppFactorySupportObjs{}, err
+		return FactorySupportObjs{}, err
 	}
 
 	dynamicClient, err := depsFactory.DynamicClient()
 	if err != nil {
-		return AppFactorySupportObjs{}, err
+		return FactorySupportObjs{}, err
 	}
 
 	fallbackAllowedNss := []string{nsFlags.Name}
@@ -43,7 +43,7 @@ func AppFactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.Namespac
 	identifiedResources := ctlres.NewIdentifiedResources(
 		coreClient, resTypes, resources, fallbackAllowedNss, logger)
 
-	result := AppFactorySupportObjs{
+	result := FactorySupportObjs{
 		CoreClient:          coreClient,
 		ResourceTypes:       resTypes,
 		IdentifiedResources: identifiedResources,
@@ -53,17 +53,17 @@ func AppFactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.Namespac
 	return result, nil
 }
 
-func AppFactory(depsFactory cmdcore.DepsFactory, appFlags AppFlags,
-	resTypesFlags ResourceTypesFlags, logger logger.Logger) (ctlapp.App, AppFactorySupportObjs, error) {
+func Factory(depsFactory cmdcore.DepsFactory, appFlags Flags,
+	resTypesFlags ResourceTypesFlags, logger logger.Logger) (ctlapp.App, FactorySupportObjs, error) {
 
-	supportingObjs, err := AppFactoryClients(depsFactory, appFlags.NamespaceFlags, resTypesFlags, logger)
+	supportingObjs, err := FactoryClients(depsFactory, appFlags.NamespaceFlags, resTypesFlags, logger)
 	if err != nil {
-		return nil, AppFactorySupportObjs{}, err
+		return nil, FactorySupportObjs{}, err
 	}
 
 	app, err := supportingObjs.Apps.Find(appFlags.Name)
 	if err != nil {
-		return nil, AppFactorySupportObjs{}, err
+		return nil, FactorySupportObjs{}, err
 	}
 
 	return app, supportingObjs, nil

--- a/pkg/kapp/cmd/app/inspect.go
+++ b/pkg/kapp/cmd/app/inspect.go
@@ -19,7 +19,7 @@ type InspectOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags            AppFlags
+	AppFlags            Flags
 	ResourceFilterFlags cmdtools.ResourceFilterFlags
 	ResourceTypesFlags  ResourceTypesFlags
 
@@ -54,7 +54,7 @@ func NewInspectCmd(o *InspectOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 func (o *InspectOptions) Run() error {
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
-	app, supportObjs, err := AppFactory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
+	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/label.go
+++ b/pkg/kapp/cmd/app/label.go
@@ -15,7 +15,7 @@ type LabelOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags AppFlags
+	AppFlags Flags
 }
 
 func NewLabelOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger) *LabelOptions {
@@ -36,7 +36,7 @@ func NewLabelCmd(o *LabelOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 }
 
 func (o *LabelOptions) Run() error {
-	app, _, err := AppFactory(o.depsFactory, o.AppFlags, ResourceTypesFlags{}, o.logger)
+	app, _, err := Factory(o.depsFactory, o.AppFlags, ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/list.go
+++ b/pkg/kapp/cmd/app/list.go
@@ -53,7 +53,7 @@ func (o *ListOptions) Run() error {
 		nsHeader.Hidden = false
 	}
 
-	supportObjs, err := AppFactoryClients(o.depsFactory, o.NamespaceFlags, ResourceTypesFlags{}, o.logger)
+	supportObjs, err := FactoryClients(o.depsFactory, o.NamespaceFlags, ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/logs.go
+++ b/pkg/kapp/cmd/app/logs.go
@@ -19,7 +19,7 @@ type LogsOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags  AppFlags
+	AppFlags  Flags
 	LogsFlags LogsFlags
 }
 
@@ -54,7 +54,7 @@ func (o *LogsOptions) Run() error {
 		return err
 	}
 
-	app, supportObjs, err := AppFactory(o.depsFactory, o.AppFlags, ResourceTypesFlags{}, o.logger)
+	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/rename.go
+++ b/pkg/kapp/cmd/app/rename.go
@@ -17,7 +17,7 @@ type RenameOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags AppFlags
+	AppFlags Flags
 	NewName  string
 }
 
@@ -40,7 +40,7 @@ func NewRenameCmd(o *RenameOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 }
 
 func (o *RenameOptions) Run() error {
-	app, _, err := AppFactory(o.depsFactory, o.AppFlags, ResourceTypesFlags{}, o.logger)
+	app, _, err := Factory(o.depsFactory, o.AppFlags, ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/appchange/gc.go
+++ b/pkg/kapp/cmd/appchange/gc.go
@@ -17,7 +17,7 @@ type GCOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags cmdapp.AppFlags
+	AppFlags cmdapp.Flags
 	Max      int
 }
 
@@ -38,7 +38,7 @@ func NewGCCmd(o *GCOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 }
 
 func (o *GCOptions) Run() error {
-	app, _, err := cmdapp.AppFactory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	app, _, err := cmdapp.Factory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/appchange/list.go
+++ b/pkg/kapp/cmd/appchange/list.go
@@ -20,7 +20,7 @@ type ListOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags cmdapp.AppFlags
+	AppFlags cmdapp.Flags
 }
 
 func NewListOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger) *ListOptions {
@@ -39,7 +39,7 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 }
 
 func (o *ListOptions) Run() error {
-	app, _, err := cmdapp.AppFactory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	app, _, err := cmdapp.Factory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/appgroup/app_group_flags.go
+++ b/pkg/kapp/cmd/appgroup/app_group_flags.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type AppGroupFlags struct {
+type Flags struct {
 	NamespaceFlags cmdcore.NamespaceFlags
 	Name           string
 }
 
-func (s *AppGroupFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
+func (s *Flags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
 	s.NamespaceFlags.Set(cmd, flagsFactory)
 
 	cmd.Flags().StringVarP(&s.Name, "group", "g", "", "Set app group name")

--- a/pkg/kapp/cmd/appgroup/delete.go
+++ b/pkg/kapp/cmd/appgroup/delete.go
@@ -23,7 +23,7 @@ type DeleteOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppGroupFlags AppGroupFlags
+	AppGroupFlags Flags
 	DeployFlags   DeployFlags
 	AppFlags      DeleteAppFlags
 }
@@ -54,7 +54,7 @@ func (o *DeleteOptions) Run() error {
 		return fmt.Errorf("Expected group name to be non-empty")
 	}
 
-	supportObjs, err := cmdapp.AppFactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	supportObjs, err := cmdapp.FactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, cmdapp.ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (o *DeleteOptions) deleteApp(name string) error {
 		name, o.AppGroupFlags.NamespaceFlags.Name)
 
 	deleteOpts := cmdapp.NewDeleteOptions(o.ui, o.depsFactory, o.logger)
-	deleteOpts.AppFlags = cmdapp.AppFlags{
+	deleteOpts.AppFlags = cmdapp.Flags{
 		Name:           name,
 		NamespaceFlags: o.AppGroupFlags.NamespaceFlags,
 	}

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -21,7 +21,7 @@ type DeployOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppGroupFlags AppGroupFlags
+	AppGroupFlags Flags
 	DeployFlags   DeployFlags
 	AppFlags      DeployAppFlags
 }
@@ -76,7 +76,7 @@ func (o *DeployOptions) Run() error {
 		}
 	}
 
-	supportObjs, err := cmdapp.AppFactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	supportObjs, err := cmdapp.FactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, cmdapp.ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (o *DeployOptions) deployApp(app appGroupApp) error {
 		app.Name, o.AppGroupFlags.NamespaceFlags.Name, app.Path)
 
 	deployOpts := cmdapp.NewDeployOptions(o.ui, o.depsFactory, o.logger)
-	deployOpts.AppFlags = cmdapp.AppFlags{
+	deployOpts.AppFlags = cmdapp.Flags{
 		Name:           app.Name,
 		NamespaceFlags: o.AppGroupFlags.NamespaceFlags,
 	}
@@ -157,7 +157,7 @@ func (o *DeployOptions) deleteApp(name string) error {
 		name, o.AppGroupFlags.NamespaceFlags.Name)
 
 	deleteOpts := cmdapp.NewDeleteOptions(o.ui, o.depsFactory, o.logger)
-	deleteOpts.AppFlags = cmdapp.AppFlags{
+	deleteOpts.AppFlags = cmdapp.Flags{
 		Name:           name,
 		NamespaceFlags: o.AppGroupFlags.NamespaceFlags,
 	}

--- a/pkg/kapp/cmd/completion.go
+++ b/pkg/kapp/cmd/completion.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/pkg/kapp/cmd/configmap/list.go
+++ b/pkg/kapp/cmd/configmap/list.go
@@ -17,7 +17,7 @@ type ListOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags cmdapp.AppFlags
+	AppFlags cmdapp.Flags
 	Values   bool
 }
 
@@ -38,7 +38,7 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 }
 
 func (o *ListOptions) Run() error {
-	app, supportObjs, err := cmdapp.AppFactory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	app, supportObjs, err := cmdapp.Factory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/core/conditions_value.go
+++ b/pkg/kapp/cmd/core/conditions_value.go
@@ -38,9 +38,9 @@ func (t ConditionsValue) String() string {
 		for _, cond := range conditions {
 			if typedCond, ok := cond.(map[string]interface{}); ok {
 				if typedStatus, ok := typedCond["status"].(string); ok {
-					totalNum += 1
+					totalNum++
 					if typedStatus == "True" {
-						okNum += 1
+						okNum++
 					}
 				}
 			}

--- a/pkg/kapp/cmd/serviceaccount/list.go
+++ b/pkg/kapp/cmd/serviceaccount/list.go
@@ -17,7 +17,7 @@ type ListOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	AppFlags cmdapp.AppFlags
+	AppFlags cmdapp.Flags
 	Values   bool
 }
 
@@ -37,7 +37,7 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 }
 
 func (o *ListOptions) Run() error {
-	app, supportObjs, err := cmdapp.AppFactory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	app, supportObjs, err := cmdapp.Factory(o.depsFactory, o.AppFlags, cmdapp.ResourceTypesFlags{}, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/diff/masked_resource.go
+++ b/pkg/kapp/diff/masked_resource.go
@@ -54,7 +54,7 @@ var (
 func (MaskedResource) maskValues(typedObj map[string]interface{}) error {
 	// Needed for deterministic value indexing
 	var sortedKeys []string
-	for k, _ := range typedObj {
+	for k := range typedObj {
 		sortedKeys = append(sortedKeys, k)
 	}
 	sort.Strings(sortedKeys)
@@ -68,13 +68,13 @@ func (MaskedResource) maskValues(typedObj map[string]interface{}) error {
 			// since it's better to indicate change when there is no change vs
 			// no change when there is actually a change.
 			maskVal = fmt.Sprintf("<-- unknown value not shown (#%d)", maskedResourceValueLastIdx)
-			maskedResourceValueLastIdx += 1
+			maskedResourceValueLastIdx++
 		} else {
 			valIdx, found := maskedResourceValues[string(valBs)]
 			if !found {
 				valIdx = maskedResourceValueLastIdx
 				maskedResourceValues[string(valBs)] = valIdx
-				maskedResourceValueLastIdx += 1
+				maskedResourceValueLastIdx++
 			}
 			maskVal = fmt.Sprintf("<-- value not shown (#%d)", valIdx)
 		}

--- a/pkg/kapp/diffgraph/change.go
+++ b/pkg/kapp/diffgraph/change.go
@@ -58,20 +58,20 @@ func (c *Change) IsDirectlyWaitingFor(changeToFind *Change) bool {
 	return false
 }
 
-func (g *Change) IsTransitivelyWaitingFor(changeToFind *Change) bool {
+func (c *Change) IsTransitivelyWaitingFor(changeToFind *Change) bool {
 	alreadyChecked := map[*Change]struct{}{}
 	alreadyVisited := map[*Change]struct{}{}
-	return g.isTransitivelyWaitingFor(changeToFind, alreadyChecked, alreadyVisited)
+	return c.isTransitivelyWaitingFor(changeToFind, alreadyChecked, alreadyVisited)
 }
 
-func (g *Change) isTransitivelyWaitingFor(changeToFind *Change,
+func (c *Change) isTransitivelyWaitingFor(changeToFind *Change,
 	alreadyChecked map[*Change]struct{}, alreadyVisited map[*Change]struct{}) bool {
 
-	if g.IsDirectlyWaitingFor(changeToFind) {
+	if c.IsDirectlyWaitingFor(changeToFind) {
 		return true
 	}
 
-	for _, change := range g.WaitingFor {
+	for _, change := range c.WaitingFor {
 		if _, checked := alreadyChecked[change]; checked {
 			continue
 		}

--- a/pkg/kapp/resources/identified_resources_list.go
+++ b/pkg/kapp/resources/identified_resources_list.go
@@ -36,7 +36,7 @@ func (r IdentifiedResources) List(labelSelector labels.Selector, resRefs []Resou
 		resTypes = MatchingAny(resTypes, resRefs)
 	}
 
-	allOpts := ResourcesAllOpts{
+	allOpts := AllOpts{
 		ListOpts: &metav1.ListOptions{
 			LabelSelector: labelSelector.String(),
 		},

--- a/pkg/kapp/resources/matcher_empty_field.go
+++ b/pkg/kapp/resources/matcher_empty_field.go
@@ -17,7 +17,7 @@ func (m EmptyFieldMatcher) Matches(res Resource) bool {
 	return m.check(res.unstructured().Object, m.Path)
 }
 
-func (t EmptyFieldMatcher) check(obj interface{}, path Path) bool {
+func (m EmptyFieldMatcher) check(obj interface{}, path Path) bool {
 	for i, part := range path {
 		switch {
 		case part.MapKey != nil:
@@ -42,7 +42,7 @@ func (t EmptyFieldMatcher) check(obj interface{}, path Path) bool {
 				}
 
 				for _, obj := range typedObj {
-					empty := t.check(obj, path[i+1:])
+					empty := m.check(obj, path[i+1:])
 					if !empty {
 						return false
 					}

--- a/pkg/kapp/resources/resource_types.go
+++ b/pkg/kapp/resources/resource_types.go
@@ -94,7 +94,7 @@ func (g *ResourceTypesImpl) canIgnoreFailingGroupVersions(groupVers map[schema.G
 		return true
 	}
 	if g.opts.CanIgnoreFailingAPIService != nil {
-		for groupVer, _ := range groupVers {
+		for groupVer := range groupVers {
 			if !g.opts.CanIgnoreFailingAPIService(groupVer) {
 				return false
 			}

--- a/pkg/kapp/resources/resources.go
+++ b/pkg/kapp/resources/resources.go
@@ -66,7 +66,7 @@ type unstructItems struct {
 	Items   []unstructured.Unstructured
 }
 
-func (c *Resources) All(resTypes []ResourceType, opts ResourcesAllOpts) ([]Resource, error) {
+func (c *Resources) All(resTypes []ResourceType, opts AllOpts) ([]Resource, error) {
 	defer c.logger.DebugFunc("All").Finish()
 
 	if opts.ListOpts == nil {
@@ -178,9 +178,6 @@ func (c *Resources) allForNamespaces(client dynamic.NamespaceableResourceInterfa
 				if !errors.IsForbidden(err) {
 					fatalErrsCh <- err
 					return
-				} else {
-					// TODO warnErrsCh <- fmt.Errorf("Listing %#v, namespaced: %t: %s", resType.GroupVersionResource, resType.Namespaced(), err)
-					// Continue trying other namespaces
 				}
 			} else {
 				unstructItemsCh <- resList
@@ -503,7 +500,7 @@ func IsResourceChangeBlockedErr(err error) bool {
 	}
 }
 
-type ResourcesAllOpts struct {
+type AllOpts struct {
 	ListOpts *metav1.ListOptions
 }
 

--- a/pkg/kapp/resourcesmisc/api_extensions_vx_crd.go
+++ b/pkg/kapp/resourcesmisc/api_extensions_vx_crd.go
@@ -8,28 +8,28 @@ import (
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 )
 
-type ApiExtensionsVxCRD struct {
+type APIExtensionsVxCRD struct {
 	resource ctlres.Resource
 }
 
-func NewApiExtensionsVxCRD(resource ctlres.Resource) *ApiExtensionsVxCRD {
+func NewAPIExtensionsVxCRD(resource ctlres.Resource) *APIExtensionsVxCRD {
 	matcher := ctlres.APIGroupKindMatcher{
 		APIGroup: "apiextensions.k8s.io",
 		Kind:     "CustomResourceDefinition",
 	}
 	if matcher.Matches(resource) {
-		return &ApiExtensionsVxCRD{resource}
+		return &APIExtensionsVxCRD{resource}
 	}
 	return nil
 }
 
-func (s ApiExtensionsVxCRD) IsDoneApplying() DoneApplyState {
+func (s APIExtensionsVxCRD) IsDoneApplying() DoneApplyState {
 	// CRD conditions: https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions
 	allTrue, msg := Conditions{s.resource}.IsSelectedTrue([]string{"Established", "NamesAccepted"})
 	return DoneApplyState{Done: allTrue, Successful: allTrue, Message: msg}
 }
 
-func (s ApiExtensionsVxCRD) contents() (crdObj, error) {
+func (s APIExtensionsVxCRD) contents() (crdObj, error) {
 	bs, err := s.resource.AsYAMLBytes()
 	if err != nil {
 		return crdObj{}, err

--- a/pkg/kapp/resourcesmisc/crds.go
+++ b/pkg/kapp/resourcesmisc/crds.go
@@ -11,16 +11,16 @@ import (
 )
 
 type ResourceTypes struct {
-	localCRDs      []*ApiExtensionsVxCRD
+	localCRDs      []*APIExtensionsVxCRD
 	resourceTypes  ctlres.ResourceTypes
 	memoizedScopes map[string]bool
 }
 
 func NewResourceTypes(newResources []ctlres.Resource, resourceTypes ctlres.ResourceTypes) *ResourceTypes {
-	var localCRDs []*ApiExtensionsVxCRD
+	var localCRDs []*APIExtensionsVxCRD
 
 	for _, newRes := range newResources {
-		crd := NewApiExtensionsVxCRD(newRes)
+		crd := NewAPIExtensionsVxCRD(newRes)
 		if crd != nil {
 			localCRDs = append(localCRDs, crd)
 		}


### PR DESCRIPTION
Adding golangci-lint to run `golint` linter to enforce go styling conventions and `goheader` to enforce whether copyright headers are present for files.