### PR TITLE
Adding Linters for Checking for Deadcode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ linters:
   enable:
     - goheader
     - golint
+    - deadcode
+    - unused
   disable-all: true
 # all available settings of specific linters
 linters-settings:

--- a/pkg/kapp/diff/change.go
+++ b/pkg/kapp/diff/change.go
@@ -18,10 +18,6 @@ const (
 	ChangeOpKeep   ChangeOp = "keep" // unchanged
 )
 
-var (
-	allChangeOps = []ChangeOp{ChangeOpAdd, ChangeOpDelete, ChangeOpUpdate, ChangeOpKeep}
-)
-
 type Change interface {
 	NewOrExistingResource() ctlres.Resource
 	NewResource() ctlres.Resource

--- a/pkg/kapp/logger/ui.go
+++ b/pkg/kapp/logger/ui.go
@@ -11,7 +11,9 @@ import (
 )
 
 const (
+	// nolint: deadcode,unused
 	loggerLevelError = "error"
+	// nolint: deadcode,unused
 	loggerLevelInfo  = "info"
 	loggerLevelDebug = "debug"
 )

--- a/pkg/kapp/logger/ui.go
+++ b/pkg/kapp/logger/ui.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	// nolint: deadcode,unused
 	loggerLevelError = "error"
-	// nolint: deadcode,unused
 	loggerLevelInfo  = "info"
 	loggerLevelDebug = "debug"
 )
@@ -31,11 +29,11 @@ func NewUILogger(ui ui.UI) *UILogger { return &UILogger{"", ui, false} }
 func (l *UILogger) SetDebug(debug bool) { l.debug = debug }
 
 func (l *UILogger) Error(msg string, args ...interface{}) {
-	l.ui.BeginLinef(l.msg(loggerLevelDebug, msg), args...)
+	l.ui.BeginLinef(l.msg(loggerLevelError, msg), args...)
 }
 
 func (l *UILogger) Info(msg string, args ...interface{}) {
-	l.ui.BeginLinef(l.msg(loggerLevelDebug, msg), args...)
+	l.ui.BeginLinef(l.msg(loggerLevelInfo, msg), args...)
 }
 
 func (l *UILogger) Debug(msg string, args ...interface{}) {

--- a/pkg/kapp/resources/association_label.go
+++ b/pkg/kapp/resources/association_label.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	kappAssociationLabelKey = "kapp.k14s.io/association"
-	kappAssociationLabelV1  = "v1"
 )
 
 type AssociationLabel struct {

--- a/pkg/kapp/resources/association_label.go
+++ b/pkg/kapp/resources/association_label.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	kappAssociationLabelKey = "kapp.k14s.io/association"
+	kappAssociationLabelV1  = "v1"
 )
 
 type AssociationLabel struct {
@@ -25,7 +26,7 @@ func NewAssociationLabel(resource Resource) AssociationLabel {
 func (a AssociationLabel) v1Value() string {
 	// max 63 char for label values
 	key := fmt.Sprintf("%x", md5.Sum([]byte(NewUniqueResourceKey(a.resource).String())))
-	return kappIdentityAnnV1 + "." + key
+	return kappAssociationLabelV1 + "." + key
 }
 
 func (a AssociationLabel) Key() string   { return kappAssociationLabelKey }

--- a/test/e2e/template_test.go
+++ b/test/e2e/template_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -288,12 +287,5 @@ func checkChangesOutput(t *testing.T, actualOutput, expectedOutput string) {
 	if actualOutput != expectedOutput {
 		t.Fatalf("Expected output to match:  %d >>>%s<<< vs %d >>>%s<<<",
 			len(actualOutput), actualOutput, len(expectedOutput), expectedOutput)
-	}
-}
-
-func printLines(heading, str string) {
-	fmt.Printf("%s:\n", heading)
-	for _, line := range strings.Split(str, "\n") {
-		fmt.Printf(">>>%s<<<\n", line)
 	}
 }


### PR DESCRIPTION
This pull request adds linters to detect if any deadcode is in any changes being added to kapp. Currently, there is very little deadcode project, but might be helpful to have a way to protect against it moving forward.