### PR TITLE
Print success message to stderr

### DIFF
--- a/cmd/kapp/kapp.go
+++ b/cmd/kapp/kapp.go
@@ -45,6 +45,6 @@ func nonExitingMain() error {
 		return err
 	}
 
-	confUI.PrintLinef("Succeeded")
+	confUI.ErrorLinef("Succeeded")
 	return nil
 }


### PR DESCRIPTION
The string "Succeeded" confuses tools that parse the output.

For example, you couldn't do `eval "$(kapp completion bash)"` without the error `Succeeded: command not found`.

Maybe don't even bother with this message and output "Error" _only_ when unsuccessful?