### PR TITLE
Check UpdatedNumberScheduled on DaemonSet apply

### DIFF
--- a/pkg/kapp/resourcesmisc/apps_v1_daemon_set_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_daemon_set_test.go
@@ -1,0 +1,149 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesmisc_test
+
+import (
+	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	ctlresm "github.com/k14s/kapp/pkg/kapp/resourcesmisc"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestAppsV1DaemonSetCreation(t *testing.T) {
+	currentData := `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  generation: 1
+`
+
+	state := buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState := ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for generation 1 to be observed",
+	}
+	require.Equal(t, expectedState, state)
+
+	currentData = `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  generation: 1
+status:
+  desiredNumberScheduled: 3
+  numberUnavailable: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 2
+`
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for 1 updated pods to be scheduled",
+	}
+	require.Equal(t, expectedState, state)
+
+	currentData = strings.Replace(currentData, "updatedNumberScheduled: 2", "updatedNumberScheduled: 3", -1)
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for 1 unavailable pods",
+	}
+	require.Equal(t, expectedState, state)
+
+	currentData = strings.Replace(currentData, "numberUnavailable: 1", "numberUnavailable: 0", -1)
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: true,
+		Message:    "",
+	}
+
+	require.Equal(t, expectedState, state)
+}
+
+func TestAppsV1DaemonSetUpdate(t *testing.T) {
+	currentData := `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  generation: 2
+status:
+  desiredNumberScheduled: 3
+  numberUnavailable: 0
+  observedGeneration: 1
+  updatedNumberScheduled: 3
+`
+
+	state := buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState := ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for generation 2 to be observed",
+	}
+	require.Equal(t, expectedState, state)
+
+	// DaemonSet controller marks one of the "current" pods for deletion. (but all number unavailable is still 0, at this moment)
+	currentData = strings.Replace(currentData, "updatedNumberScheduled: 3", "updatedNumberScheduled: 0", -1) // new image ==> new updateRevision ==> now, there are no pods of that revision
+	currentData = strings.Replace(currentData, "observedGeneration: 1", "observedGeneration: 2", -1)
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for 3 updated pods to be scheduled",
+	}
+	require.Equal(t, expectedState, state)
+
+	// DaemonSet Controller deleted one pod, and replaced it with one updated pod.
+	currentData = strings.Replace(currentData, "updatedNumberScheduled: 0", "updatedNumberScheduled: 1", -1)
+	currentData = strings.Replace(currentData, "numberUnavailable: 0", "numberUnavailable: 1", -1)
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for 2 updated pods to be scheduled",
+	}
+	require.Equal(t, expectedState, state)
+
+	// DaemonSet Controller updated all pods, and all but the last pod are available.
+	currentData = strings.Replace(currentData, "updatedNumberScheduled: 1", "updatedNumberScheduled: 3", -1)
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       false,
+		Successful: false,
+		Message:    "Waiting for 1 unavailable pods",
+	}
+	require.Equal(t, expectedState, state)
+
+	currentData = strings.Replace(currentData, "numberUnavailable: 1", "numberUnavailable: 0", -1)
+
+	state = buildDaemonSet(currentData, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: true,
+		Message:    "",
+	}
+	require.Equal(t, expectedState, state)
+}
+
+func buildDaemonSet(resourcesBs string, t *testing.T) *ctlresm.AppsV1DaemonSet {
+	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
+	if err != nil {
+		t.Fatalf("Expected resources to parse")
+	}
+
+	return ctlresm.NewAppsV1DaemonSet(newResources[0])
+}


### PR DESCRIPTION
When updating cf-for-k8s on a GKE cluster, we observe unexpectedly fast daemonset reconciliation. And after kapp returns successful, we observe daemonset pods continuing to roll. There appears to be a race condition between the pod scheduler and kapp's number unavailable pod check on daemonset update which returns successful if kapp checks the state of the daemonset before the first pod is deleted as part of the update.

To mitigate this, we've added a check for the number of updated pods scheduled on the IsDoneApplying function for daemonsets.

Thanks,
Andrew and @davewalter 