### PR TITLE
make diff-exit-status work for app-group deployments

### DIFF
--- a/pkg/kapp/cmd/app/deploy_diff_exit_status.go
+++ b/pkg/kapp/cmd/app/deploy_diff_exit_status.go
@@ -12,14 +12,14 @@ type ExitStatus interface {
 }
 
 type DeployDiffExitStatus struct {
-	hasNoChanges bool
+	HasNoChanges bool
 }
 
 var _ ExitStatus = DeployDiffExitStatus{}
 
 func (d DeployDiffExitStatus) Error() string {
 	numStr := "pending changes"
-	if d.hasNoChanges {
+	if d.HasNoChanges {
 		numStr = "no pending changes"
 	}
 	return fmt.Sprintf("Exiting after diffing with %s (exit status %d)",
@@ -27,7 +27,7 @@ func (d DeployDiffExitStatus) Error() string {
 }
 
 func (d DeployDiffExitStatus) ExitStatus() int {
-	if d.hasNoChanges {
+	if d.HasNoChanges {
 		return 2
 	}
 	return 3

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -102,7 +102,7 @@ func (o *DeployOptions) Run() error {
 	}
 
 	if o.AppFlags.DiffFlags.Run && o.AppFlags.DiffFlags.ExitStatus {
-		var hasNoChanges = exitCode == 3
+		var hasNoChanges = exitCode == 2
 		return cmdapp.DeployDiffExitStatus{HasNoChanges: hasNoChanges}
 	}
 

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -74,10 +74,10 @@ func (o *DeployOptions) Run() error {
 		err := o.deployApp(appGroupApp)
 		if err != nil {
             if deployErr, ok := err.(cmdapp.DeployDiffExitStatus); ok {
-				exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
-			} else {
-				return err
-			}
+                exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
+            } else {
+                return err
+            }
 		}
 	}
 

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -110,7 +110,7 @@ func (o *DeployOptions) Run() error {
 	}
 
 	if o.AppFlags.DiffFlags.Run && o.AppFlags.DiffFlags.ExitStatus {
-		var hasNoChanges = exitCode < 1
+		var hasNoChanges = exitCode < 3
 		return cmdapp.DeployDiffExitStatus{HasNoChanges: hasNoChanges}
 	}
 

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -73,11 +73,11 @@ func (o *DeployOptions) Run() error {
 	for _, appGroupApp := range updatedApps {
 		err := o.deployApp(appGroupApp)
 		if err != nil {
-            if deployErr, ok := err.(cmdapp.DeployDiffExitStatus); ok {
-                exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
-            } else {
-                return err
-            }
+			if deployErr, ok := err.(cmdapp.DeployDiffExitStatus); ok {
+				exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"math"
 	"path/filepath"
-	"reflect"
-
 	"github.com/cppforlife/go-cli-ui/ui"
 	cmdapp "github.com/k14s/kapp/pkg/kapp/cmd/app"
 	cmdcore "github.com/k14s/kapp/pkg/kapp/cmd/core"
@@ -75,14 +73,8 @@ func (o *DeployOptions) Run() error {
 	for _, appGroupApp := range updatedApps {
 		err := o.deployApp(appGroupApp)
 		if err != nil {
-			if reflect.TypeOf(err).Name() == "DeployDiffExitStatus" {
-				var deployErr cmdapp.DeployDiffExitStatus = err.(cmdapp.DeployDiffExitStatus)
-
-				if deployErr.ExitStatus() == 1 {
-					return err
-				}
+            if deployErr, ok := err.(cmdapp.DeployDiffExitStatus); ok {
 				exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
-
 			} else {
 				return err
 			}
@@ -110,7 +102,7 @@ func (o *DeployOptions) Run() error {
 	}
 
 	if o.AppFlags.DiffFlags.Run && o.AppFlags.DiffFlags.ExitStatus {
-		var hasNoChanges = exitCode < 3
+		var hasNoChanges = exitCode == 3
 		return cmdapp.DeployDiffExitStatus{HasNoChanges: hasNoChanges}
 	}
 

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -80,9 +80,9 @@ func (o *DeployOptions) Run() error {
 
 				if deployErr.ExitStatus() == 1 {
 					return err
-				} else {
-					exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
 				}
+				exitCode = math.Max(exitCode, float64(deployErr.ExitStatus()))
+
 			} else {
 				return err
 			}


### PR DESCRIPTION
fixes https://github.com/vmware-tanzu/carvel-kapp/issues/166 by making app-group deployments not fail if a single app returns exit status 2 or 3.