### PR TITLE
Add --warnings flag (#257)

### DIFF
--- a/pkg/kapp/cmd/core/deps_factory.go
+++ b/pkg/kapp/cmd/core/deps_factory.go
@@ -6,7 +6,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/cppforlife/go-cli-ui/ui"
@@ -124,7 +123,17 @@ func (f *DepsFactoryImpl) newWarningHandler() rest.WarningHandler {
 	}
 	options := rest.WarningWriterOptions{
 		Deduplicate: true,
+		Color:       true,
 	}
-	warningWriter := rest.NewWarningWriter(os.Stderr, options)
+	warningWriter := rest.NewWarningWriter(uiWriter{ui: f.ui}, options)
 	return warningWriter
+}
+
+type uiWriter struct {
+	ui ui.UI
+}
+
+func (w uiWriter) Write(data []byte) (int, error) {
+	w.ui.BeginLinef("%s", data)
+	return len(data), nil
 }

--- a/pkg/kapp/cmd/core/deps_factory.go
+++ b/pkg/kapp/cmd/core/deps_factory.go
@@ -18,7 +18,7 @@ import (
 type DepsFactory interface {
 	DynamicClient() (dynamic.Interface, error)
 	CoreClient() (kubernetes.Interface, error)
-	ConfigureDeprecationWarning(noDeprecationWarnings bool)
+	ConfigureWarnings(warnings bool)
 }
 
 type DepsFactoryImpl struct {
@@ -26,7 +26,7 @@ type DepsFactoryImpl struct {
 	ui              ui.UI
 	printTargetOnce *sync.Once
 
-	NoDeprecationWarnings bool
+	Warnings bool
 }
 
 var _ DepsFactory = &DepsFactoryImpl{}
@@ -46,7 +46,7 @@ func (f *DepsFactoryImpl) DynamicClient() (dynamic.Interface, error) {
 
 	// copy to avoid mutating the passed-in config
 	cpConfig := rest.CopyConfig(config)
-	if f.NoDeprecationWarnings {
+	if !f.Warnings {
 		cpConfig.WarningHandler = rest.NoWarnings{}
 	}
 
@@ -76,8 +76,8 @@ func (f *DepsFactoryImpl) CoreClient() (kubernetes.Interface, error) {
 	return clientset, nil
 }
 
-func (f *DepsFactoryImpl) ConfigureDeprecationWarning(noDeprecationWarnings bool) {
-	f.NoDeprecationWarnings = noDeprecationWarnings
+func (f *DepsFactoryImpl) ConfigureWarnings(warnings bool) {
+	f.Warnings = warnings
 }
 
 func (f *DepsFactoryImpl) printTarget(config *rest.Config) {

--- a/pkg/kapp/cmd/kapp.go
+++ b/pkg/kapp/cmd/kapp.go
@@ -30,6 +30,7 @@ type KappOptions struct {
 	LoggerFlags     LoggerFlags
 	KubeAPIFlags    cmdcore.KubeAPIFlags
 	KubeconfigFlags cmdcore.KubeconfigFlags
+	WarningFlags    WarningFlags
 }
 
 func NewKappOptions(ui *ui.ConfUI, configFactory cmdcore.ConfigFactory,
@@ -78,6 +79,7 @@ func NewKappCmd(o *KappOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 	o.LoggerFlags.Set(cmd, flagsFactory)
 	o.KubeAPIFlags.Set(cmd, flagsFactory)
 	o.KubeconfigFlags.Set(cmd, flagsFactory)
+	o.WarningFlags.Set(cmd, flagsFactory)
 
 	o.configFactory.ConfigurePathResolver(o.KubeconfigFlags.Path.Value)
 	o.configFactory.ConfigureContextResolver(o.KubeconfigFlags.Context.Value)
@@ -132,6 +134,7 @@ func NewKappCmd(o *KappOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		o.UIFlags.ConfigureUI(o.ui)
 		o.LoggerFlags.Configure(o.logger)
 		o.KubeAPIFlags.Configure(o.configFactory)
+		o.WarningFlags.Configure(o.depsFactory)
 		return nil
 	})
 

--- a/pkg/kapp/cmd/warning_flags.go
+++ b/pkg/kapp/cmd/warning_flags.go
@@ -9,13 +9,13 @@ import (
 )
 
 type WarningFlags struct {
-	NoDeprecationWarnings bool
+	Warnings bool
 }
 
 func (f *WarningFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
-	cmd.PersistentFlags().BoolVar(&f.NoDeprecationWarnings, "no-deprecation-warnings", false, "Silence deprecation warnings")
+	cmd.PersistentFlags().BoolVar(&f.Warnings, "warnings", true, "Show warnings")
 }
 
 func (f *WarningFlags) Configure(depsFactory cmdcore.DepsFactory) {
-	depsFactory.ConfigureDeprecationWarning(f.NoDeprecationWarnings)
+	depsFactory.ConfigureWarnings(f.Warnings)
 }

--- a/pkg/kapp/cmd/warning_flags.go
+++ b/pkg/kapp/cmd/warning_flags.go
@@ -1,0 +1,21 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	cmdcore "github.com/k14s/kapp/pkg/kapp/cmd/core"
+	"github.com/spf13/cobra"
+)
+
+type WarningFlags struct {
+	NoDeprecationWarnings bool
+}
+
+func (f *WarningFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
+	cmd.PersistentFlags().BoolVar(&f.NoDeprecationWarnings, "no-deprecation-warnings", false, "Silence deprecation warnings")
+}
+
+func (f *WarningFlags) Configure(depsFactory cmdcore.DepsFactory) {
+	depsFactory.ConfigureDeprecationWarning(f.NoDeprecationWarnings)
+}

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNoDeprecationWarnings(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
+
+	name := "test-no-warnings"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	yaml1 := `
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: itachi
+spec:
+  rules:
+  - host: localhost
+    http:
+      paths:
+      - backend:
+          serviceName: itachi
+          servicePort: 80
+          path: /
+          pathType: ImplementationSpecific
+`
+	logger.Section("deploying without --no-deprecation-warning flag", func() {
+		out := new(bytes.Buffer)
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{StdinReader: strings.NewReader(yaml1), StderrWriter: out})
+		if !strings.Contains(out.String(), "extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress") {
+			t.Fatalf("Expected deprecation warnings, but didn't get")
+		}
+	})
+	cleanUp()
+	logger.Section("deploying with --no-deprecation-warning flag", func() {
+		out := new(bytes.Buffer)
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--no-deprecation-warnings"},
+			RunOpts{StdinReader: strings.NewReader(yaml1), StderrWriter: out})
+		if strings.Contains(out.String(), "extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress") {
+			t.Fatalf("Expected no deprecation warnings, but got")
+		}
+	})
+}

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 	"testing"
@@ -80,19 +79,19 @@ spec:
 	})
 	logger.Section("deploying without --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-1", 1)
-		out := new(bytes.Buffer)
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
-			RunOpts{StdinReader: strings.NewReader(yaml), StderrWriter: out})
-		if !strings.Contains(out.String(), customWarning) {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
+			RunOpts{StdinReader: strings.NewReader(yaml)})
+
+		if !strings.Contains(out, customWarning) {
 			t.Fatalf("Expected warning %s, but didn't get", customWarning)
 		}
 	})
 	logger.Section("deploying with --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
-		out := new(bytes.Buffer)
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=false"},
-			RunOpts{StdinReader: strings.NewReader(yaml), StderrWriter: out})
-		if strings.Contains(out.String(), customWarning) {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=false"},
+			RunOpts{StdinReader: strings.NewReader(yaml)})
+
+		if strings.Contains(out, customWarning) {
 			t.Fatalf("Expected no warning, but got %s", customWarning)
 		}
 	})


### PR DESCRIPTION
Add `--warning` flag with default set to `true`
Add test which uses a CRD with a custom deprecated version and warning.
Skip test if version less than 1.19 as CLI warnings were introduced in v1.19 (https://kubernetes.io/blog/2020/09/03/warnings/).