### PR TITLE
Set default value of warnings flag to false

### DIFF
--- a/pkg/kapp/cmd/warning_flags.go
+++ b/pkg/kapp/cmd/warning_flags.go
@@ -13,7 +13,7 @@ type WarningFlags struct {
 }
 
 func (f *WarningFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
-	cmd.PersistentFlags().BoolVar(&f.Warnings, "warnings", true, "Show warnings")
+	cmd.PersistentFlags().BoolVar(&f.Warnings, "warnings", false, "Show warnings")
 }
 
 func (f *WarningFlags) Configure(depsFactory cmdcore.DepsFactory) {

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -77,7 +77,7 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crdName},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 	})
-	logger.Section("deploying without --warnings flag", func() {
+	logger.Section("deploying with --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-1", 1)
 		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=true"},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
@@ -86,7 +86,7 @@ spec:
 			t.Fatalf("Expected warning %s, but didn't get", customWarning)
 		}
 	})
-	logger.Section("deploying with --warnings flag", func() {
+	logger.Section("deploying without --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
 		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
 			RunOpts{StdinReader: strings.NewReader(yaml)})

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -79,7 +79,7 @@ spec:
 	})
 	logger.Section("deploying without --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-1", 1)
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=true"},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 
 		if !strings.Contains(out, customWarning) {
@@ -88,7 +88,7 @@ spec:
 	})
 	logger.Section("deploying with --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=false"},
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 
 		if strings.Contains(out, customWarning) {


### PR DESCRIPTION
This is a temporary solution, we should revert it once we find a concrete solution to the deprecation warnings being produced due to the list api call.