### PR TITLE
Improving how warnings are displayed

### DIFF
--- a/pkg/kapp/cmd/app/factory.go
+++ b/pkg/kapp/cmd/app/factory.go
@@ -31,6 +31,11 @@ func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFl
 		return FactorySupportObjs{}, err
 	}
 
+	mutedDynamicClient, err := depsFactory.MutedDynamicClient()
+	if err != nil {
+		return FactorySupportObjs{}, err
+	}
+
 	fallbackAllowedNss := []string{nsFlags.Name}
 
 	resTypes := ctlres.NewResourceTypesImpl(coreClient, ctlres.ResourceTypesImplOpts{
@@ -38,7 +43,7 @@ func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFl
 		CanIgnoreFailingAPIService: resTypesFlags.CanIgnoreFailingAPIService,
 	})
 
-	resources := ctlres.NewResourcesImpl(resTypes, coreClient, dynamicClient, fallbackAllowedNss, logger)
+	resources := ctlres.NewResourcesImpl(resTypes, coreClient, dynamicClient, mutedDynamicClient, fallbackAllowedNss, logger)
 
 	identifiedResources := ctlres.NewIdentifiedResources(
 		coreClient, resTypes, resources, fallbackAllowedNss, logger)

--- a/pkg/kapp/cmd/app/factory.go
+++ b/pkg/kapp/cmd/app/factory.go
@@ -26,12 +26,12 @@ func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFl
 		return FactorySupportObjs{}, err
 	}
 
-	dynamicClient, err := depsFactory.DynamicClient()
+	dynamicClient, err := depsFactory.DynamicClient(true)
 	if err != nil {
 		return FactorySupportObjs{}, err
 	}
 
-	mutedDynamicClient, err := depsFactory.MutedDynamicClient()
+	mutedDynamicClient, err := depsFactory.DynamicClient(false)
 	if err != nil {
 		return FactorySupportObjs{}, err
 	}

--- a/pkg/kapp/cmd/app/factory.go
+++ b/pkg/kapp/cmd/app/factory.go
@@ -26,12 +26,12 @@ func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFl
 		return FactorySupportObjs{}, err
 	}
 
-	dynamicClient, err := depsFactory.DynamicClient(true)
+	dynamicClient, err := depsFactory.DynamicClient(cmdcore.DynamicClientOpts{Warnings: true})
 	if err != nil {
 		return FactorySupportObjs{}, err
 	}
 
-	mutedDynamicClient, err := depsFactory.DynamicClient(false)
+	mutedDynamicClient, err := depsFactory.DynamicClient(cmdcore.DynamicClientOpts{Warnings: false})
 	if err != nil {
 		return FactorySupportObjs{}, err
 	}

--- a/pkg/kapp/cmd/app/inspect.go
+++ b/pkg/kapp/cmd/app/inspect.go
@@ -11,6 +11,7 @@ import (
 	cmdtools "github.com/k14s/kapp/pkg/kapp/cmd/tools"
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
 	"github.com/k14s/kapp/pkg/kapp/logger"
+	"github.com/k14s/kapp/pkg/kapp/resources"
 	"github.com/spf13/cobra"
 )
 
@@ -86,6 +87,8 @@ func (o *InspectOptions) Run() error {
 	resources = resourceFilter.Apply(resources)
 	source := fmt.Sprintf("app '%s'", app.Name())
 
+	o.checkDeprecation(resources, supportObjs)
+
 	switch {
 	case o.Raw:
 		for _, res := range resources {
@@ -118,4 +121,10 @@ func (o *InspectOptions) Run() error {
 	}
 
 	return nil
+}
+
+func (o *InspectOptions) checkDeprecation(resources []resources.Resource, supportingObjs FactorySupportObjs) {
+	for _, r := range resources {
+		supportingObjs.IdentifiedResources.Get(r)
+	}
 }

--- a/pkg/kapp/cmd/app/inspect.go
+++ b/pkg/kapp/cmd/app/inspect.go
@@ -11,7 +11,6 @@ import (
 	cmdtools "github.com/k14s/kapp/pkg/kapp/cmd/tools"
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
 	"github.com/k14s/kapp/pkg/kapp/logger"
-	"github.com/k14s/kapp/pkg/kapp/resources"
 	"github.com/spf13/cobra"
 )
 
@@ -87,8 +86,6 @@ func (o *InspectOptions) Run() error {
 	resources = resourceFilter.Apply(resources)
 	source := fmt.Sprintf("app '%s'", app.Name())
 
-	o.checkDeprecation(resources, supportObjs)
-
 	switch {
 	case o.Raw:
 		for _, res := range resources {
@@ -121,10 +118,4 @@ func (o *InspectOptions) Run() error {
 	}
 
 	return nil
-}
-
-func (o *InspectOptions) checkDeprecation(resources []resources.Resource, supportingObjs FactorySupportObjs) {
-	for _, r := range resources {
-		supportingObjs.IdentifiedResources.Get(r)
-	}
 }

--- a/pkg/kapp/cmd/core/deps_factory.go
+++ b/pkg/kapp/cmd/core/deps_factory.go
@@ -132,7 +132,7 @@ func (f *DepsFactoryImpl) newWarningHandler() rest.WarningHandler {
 	}
 	options := rest.WarningWriterOptions{
 		Deduplicate: true,
-		Color:       true,
+		Color:       false,
 	}
 	warningWriter := rest.NewWarningWriter(uiWriter{ui: f.ui}, options)
 	return warningWriter

--- a/pkg/kapp/cmd/core/deps_factory.go
+++ b/pkg/kapp/cmd/core/deps_factory.go
@@ -16,7 +16,7 @@ import (
 )
 
 type DepsFactory interface {
-	DynamicClient(warnings bool) (dynamic.Interface, error)
+	DynamicClient(opts DynamicClientOpts) (dynamic.Interface, error)
 	CoreClient() (kubernetes.Interface, error)
 	ConfigureWarnings(warnings bool)
 }
@@ -38,7 +38,11 @@ func NewDepsFactoryImpl(configFactory ConfigFactory, ui ui.UI) *DepsFactoryImpl 
 		printTargetOnce: &sync.Once{}}
 }
 
-func (f *DepsFactoryImpl) DynamicClient(warnings bool) (dynamic.Interface, error) {
+type DynamicClientOpts struct {
+	Warnings bool
+}
+
+func (f *DepsFactoryImpl) DynamicClient(opts DynamicClientOpts) (dynamic.Interface, error) {
 	config, err := f.configFactory.RESTConfig()
 	if err != nil {
 		return nil, err
@@ -47,7 +51,7 @@ func (f *DepsFactoryImpl) DynamicClient(warnings bool) (dynamic.Interface, error
 	// copy to avoid mutating the passed-in config
 	cpConfig := rest.CopyConfig(config)
 
-	if warnings {
+	if opts.Warnings {
 		cpConfig.WarningHandler = f.newWarningHandler()
 	} else {
 		cpConfig.WarningHandler = rest.NoWarnings{}

--- a/pkg/kapp/cmd/tools/list_labels.go
+++ b/pkg/kapp/cmd/tools/list_labels.go
@@ -122,12 +122,12 @@ func (o *ListLabelsOptions) listResources() ([]ctlres.Resource, error) {
 		return nil, err
 	}
 
-	dynamicClient, err := o.depsFactory.DynamicClient(true)
+	dynamicClient, err := o.depsFactory.DynamicClient(cmdcore.DynamicClientOpts{Warnings: true})
 	if err != nil {
 		return nil, err
 	}
 
-	mutedDynamicClient, err := o.depsFactory.DynamicClient(false)
+	mutedDynamicClient, err := o.depsFactory.DynamicClient(cmdcore.DynamicClientOpts{Warnings: false})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kapp/cmd/tools/list_labels.go
+++ b/pkg/kapp/cmd/tools/list_labels.go
@@ -122,12 +122,12 @@ func (o *ListLabelsOptions) listResources() ([]ctlres.Resource, error) {
 		return nil, err
 	}
 
-	dynamicClient, err := o.depsFactory.DynamicClient()
+	dynamicClient, err := o.depsFactory.DynamicClient(true)
 	if err != nil {
 		return nil, err
 	}
 
-	mutedDynamicClient, err := o.depsFactory.DynamicClient()
+	mutedDynamicClient, err := o.depsFactory.DynamicClient(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kapp/cmd/tools/list_labels.go
+++ b/pkg/kapp/cmd/tools/list_labels.go
@@ -127,8 +127,13 @@ func (o *ListLabelsOptions) listResources() ([]ctlres.Resource, error) {
 		return nil, err
 	}
 
+	mutedDynamicClient, err := o.depsFactory.DynamicClient()
+	if err != nil {
+		return nil, err
+	}
+
 	resTypes := ctlres.NewResourceTypesImpl(coreClient, ctlres.ResourceTypesImplOpts{})
-	resources := ctlres.NewResourcesImpl(resTypes, coreClient, dynamicClient, nil, o.logger)
+	resources := ctlres.NewResourcesImpl(resTypes, coreClient, dynamicClient, mutedDynamicClient, nil, o.logger)
 	identifiedResources := ctlres.NewIdentifiedResources(coreClient, resTypes, resources, nil, o.logger)
 
 	labelSelector, err := labels.Parse("!kapp")

--- a/pkg/kapp/cmd/warning_flags.go
+++ b/pkg/kapp/cmd/warning_flags.go
@@ -13,7 +13,7 @@ type WarningFlags struct {
 }
 
 func (f *WarningFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
-	cmd.PersistentFlags().BoolVar(&f.Warnings, "warnings", false, "Show warnings")
+	cmd.PersistentFlags().BoolVar(&f.Warnings, "warnings", true, "Show warnings")
 }
 
 func (f *WarningFlags) Configure(depsFactory cmdcore.DepsFactory) {

--- a/pkg/kapp/resources/resources.go
+++ b/pkg/kapp/resources/resources.go
@@ -225,7 +225,7 @@ func (c *ResourcesImpl) Create(resource Resource) (Resource, error) {
 		c.logger.Debug("create resource %s\n%s\n", resource.Description(), bs)
 	}
 
-	resClient, resType, err := c.resourceClient(resource)
+	resClient, resType, err := c.resourceClient(resource, false)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (c *ResourcesImpl) Update(resource Resource) (Resource, error) {
 		c.logger.Debug("update resource %s\n%s\n", resource.Description(), bs)
 	}
 
-	resClient, resType, err := c.resourceClient(resource)
+	resClient, resType, err := c.resourceClient(resource, false)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (c *ResourcesImpl) Patch(resource Resource, patchType types.PatchType, data
 		defer func() { c.logger.Debug("patch %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, resType, err := c.resourceClient(resource)
+	resClient, resType, err := c.resourceClient(resource, false)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (c *ResourcesImpl) Delete(resource Resource) error {
 		return nil
 	}
 
-	resClient, resType, err := c.resourceClient(resource)
+	resClient, resType, err := c.resourceClient(resource, false)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (c *ResourcesImpl) Get(resource Resource) (Resource, error) {
 		defer func() { c.logger.Debug("get %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, resType, err := c.resourceClient(resource)
+	resClient, resType, err := c.resourceClient(resource, true)
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +371,7 @@ func (c *ResourcesImpl) Exists(resource Resource) (bool, error) {
 		defer func() { c.logger.Debug("exists %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, _, err := c.resourceClient(resource)
+	resClient, _, err := c.resourceClient(resource, false)
 	if err != nil {
 		// Assume if type is not known to the API server
 		// then such resource cannot exist on the server
@@ -475,10 +475,14 @@ func (c *ResourcesImpl) resourceErr(err error, action string, resource Resource)
 	return resourcePlainErr{err, action, resource}
 }
 
-func (c *ResourcesImpl) resourceClient(resource Resource) (dynamic.ResourceInterface, ResourceType, error) {
+func (c *ResourcesImpl) resourceClient(resource Resource, muted bool) (dynamic.ResourceInterface, ResourceType, error) {
 	resType, err := c.resourceTypes.Find(resource)
 	if err != nil {
 		return nil, ResourceType{}, err
+	}
+
+	if muted {
+		return c.mutedDynamicClient.Resource(resType.GroupVersionResource).Namespace(resource.Namespace()), resType, nil
 	}
 
 	return c.dynamicClient.Resource(resType.GroupVersionResource).Namespace(resource.Namespace()), resType, nil

--- a/pkg/kapp/resources/resources.go
+++ b/pkg/kapp/resources/resources.go
@@ -225,7 +225,7 @@ func (c *ResourcesImpl) Create(resource Resource) (Resource, error) {
 		c.logger.Debug("create resource %s\n%s\n", resource.Description(), bs)
 	}
 
-	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{warnings: true})
+	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{Warnings: true})
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (c *ResourcesImpl) Update(resource Resource) (Resource, error) {
 		c.logger.Debug("update resource %s\n%s\n", resource.Description(), bs)
 	}
 
-	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{warnings: true})
+	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{Warnings: true})
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (c *ResourcesImpl) Patch(resource Resource, patchType types.PatchType, data
 		defer func() { c.logger.Debug("patch %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{warnings: true})
+	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{Warnings: true})
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (c *ResourcesImpl) Delete(resource Resource) error {
 		return nil
 	}
 
-	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{warnings: true})
+	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{Warnings: true})
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (c *ResourcesImpl) Get(resource Resource) (Resource, error) {
 		defer func() { c.logger.Debug("get %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{warnings: false})
+	resClient, resType, err := c.resourceClient(resource, resourceClientOpts{Warnings: false})
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +371,7 @@ func (c *ResourcesImpl) Exists(resource Resource) (bool, error) {
 		defer func() { c.logger.Debug("exists %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, _, err := c.resourceClient(resource, resourceClientOpts{warnings: true})
+	resClient, _, err := c.resourceClient(resource, resourceClientOpts{Warnings: true})
 	if err != nil {
 		// Assume if type is not known to the API server
 		// then such resource cannot exist on the server
@@ -476,7 +476,7 @@ func (c *ResourcesImpl) resourceErr(err error, action string, resource Resource)
 }
 
 type resourceClientOpts struct {
-	warnings bool
+	Warnings bool
 }
 
 func (c *ResourcesImpl) resourceClient(resource Resource, opts resourceClientOpts) (dynamic.ResourceInterface, ResourceType, error) {
@@ -485,11 +485,14 @@ func (c *ResourcesImpl) resourceClient(resource Resource, opts resourceClientOpt
 		return nil, ResourceType{}, err
 	}
 
-	if !opts.warnings {
-		return c.mutedDynamicClient.Resource(resType.GroupVersionResource).Namespace(resource.Namespace()), resType, nil
+	var dynamicClient dynamic.Interface
+	if opts.Warnings {
+		dynamicClient = c.dynamicClient
+	} else {
+		dynamicClient = c.mutedDynamicClient
 	}
 
-	return c.dynamicClient.Resource(resType.GroupVersionResource).Namespace(resource.Namespace()), resType, nil
+	return dynamicClient.Resource(resType.GroupVersionResource).Namespace(resource.Namespace()), resType, nil
 }
 
 func (c *ResourcesImpl) assumedAllowedNamespaces() ([]string, error) {

--- a/pkg/kapp/resources/resources.go
+++ b/pkg/kapp/resources/resources.go
@@ -371,7 +371,7 @@ func (c *ResourcesImpl) Exists(resource Resource) (bool, error) {
 		defer func() { c.logger.Debug("exists %s", time.Now().UTC().Sub(t1)) }()
 	}
 
-	resClient, _, err := c.resourceClient(resource, resourceClientOpts{Warnings: true})
+	resClient, _, err := c.resourceClient(resource, resourceClientOpts{Warnings: false})
 	if err != nil {
 		// Assume if type is not known to the API server
 		// then such resource cannot exist on the server

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -4,18 +4,12 @@
 package e2e
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	yellowColor = "\u001b[33;1m"
-	resetColor  = "\u001b[0m"
 )
 
 func TestWarningsFlag(t *testing.T) {
@@ -41,7 +35,6 @@ func TestWarningsFlag(t *testing.T) {
 	cleanUp()
 	defer cleanUp()
 	customWarning := "example.com/v1alpha1 CronTab is deprecated; use example.com/v1 CronTab"
-	outputWarning := fmt.Sprintf("%sWarning:%s %s", yellowColor, resetColor, customWarning)
 
 	crdYaml := `
 apiVersion: apiextensions.k8s.io/v1
@@ -102,7 +95,7 @@ Op:      1 create, 0 delete, 0 update, 0 noop
 Wait to: 1 reconcile, 0 delete, 0 noop
 
 <replaced>: ---- applying 1 changes [0/1 done] ----
-<outputWarning>
+Warning: <custom-warning>
 <replaced>: create crontab/cr-1 (stable.example.com/v1alpha1) namespace: kapp-test
 <replaced>: ---- waiting on 1 changes [0/1 done] ----
 <replaced>: ok: reconcile crontab/cr-1 (stable.example.com/v1alpha1) namespace: kapp-test
@@ -112,7 +105,7 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 Succeeded`
 
 		out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
-		expectedOutput = strings.Replace(expectedOutput, "<outputWarning>", outputWarning, 1)
+		expectedOutput = strings.Replace(expectedOutput, "<custom-warning>", customWarning, 1)
 		expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
 
 		if expectedOutput != out {

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -4,12 +4,18 @@
 package e2e
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	yellowColor = "\u001b[33;1m"
+	resetColor  = "\u001b[0m"
 )
 
 func TestWarningsFlag(t *testing.T) {
@@ -24,15 +30,18 @@ func TestWarningsFlag(t *testing.T) {
 	logger := Logger{}
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
 	crdName := "test-no-warnings-crd"
-	crName := "test-no-warnings-cr"
+	crName1 := "test-no-warnings-cr1"
+	crName2 := "test-no-warnings-cr2"
 	cleanUp := func() {
-		kapp.Run([]string{"delete", "-a", crName})
+		kapp.Run([]string{"delete", "-a", crName1})
+		kapp.Run([]string{"delete", "-a", crName2})
 		kapp.Run([]string{"delete", "-a", crdName})
 	}
 
 	cleanUp()
 	defer cleanUp()
 	customWarning := "example.com/v1alpha1 CronTab is deprecated; use example.com/v1 CronTab"
+	outputWarning := fmt.Sprintf("\n%sWarning:%s %s", yellowColor, resetColor, customWarning)
 
 	crdYaml := `
 apiVersion: apiextensions.k8s.io/v1
@@ -72,27 +81,62 @@ spec:
   image: my-awesome-cron-image
 `
 
+	expectedOutputTemplate := `
+Target cluster 'https://127.0.0.1:60817' (nodes: minikube)
+
+Changes
+
+Namespace  Name  Kind     Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
+kapp-test  <cr-name>  CronTab  -       -    create  -       reconcile  -   -  
+
+Op:      1 create, 0 delete, 0 update, 0 noop
+Wait to: 1 reconcile, 0 delete, 0 noop
+
+<replaced>: ---- applying 1 changes [0/1 done] ----<output-warning>
+<replaced>: create crontab/<cr-name> (stable.example.com/v1alpha1) namespace: kapp-test
+<replaced>: ---- waiting on 1 changes [0/1 done] ----
+<replaced>: ok: reconcile crontab/<cr-name> (stable.example.com/v1alpha1) namespace: kapp-test
+<replaced>: ---- applying complete [1/1 done] ----
+<replaced>: ---- waiting complete [1/1 done] ----
+
+Succeeded`
+
 	logger.Section("deploying crd with deprecated version", func() {
 		yaml := strings.Replace(crdYaml, "<customWarning>", customWarning, 1)
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crdName},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 	})
+
 	logger.Section("deploying without --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-1", 1)
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
+
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName1},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 
-		if !strings.Contains(out, customWarning) {
-			t.Fatalf("Expected warning %s, but didn't get", customWarning)
+		expectedOutput := strings.Replace(expectedOutputTemplate, "<cr-name>", "cr-1", 3)
+
+		out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
+		expectedOutput = strings.Replace(expectedOutput, "<output-warning>", outputWarning, 1)
+		expectedOutput = strings.TrimSpace(replaceTarget(replaceSpaces(expectedOutput)))
+
+		if expectedOutput != out {
+			t.Fatalf("Expected output with warning >>%s<<, but got >>%s<<\n", expectedOutput, out)
 		}
 	})
+
 	logger.Section("deploying with --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=false"},
+
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName2, "--warnings=false"},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 
-		if strings.Contains(out, customWarning) {
-			t.Fatalf("Expected no warning, but got %s", customWarning)
+		expectedOutput := strings.Replace(expectedOutputTemplate, "<cr-name>", "cr-2", 3)
+
+		out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
+		expectedOutput = strings.Replace(expectedOutput, "<output-warning>", "", 1)
+		expectedOutput = strings.TrimSpace(replaceTarget(replaceSpaces(expectedOutput)))
+		if expectedOutput != out {
+			t.Fatalf("Expected output without warning >>%s<< but got >>%s<<\n", expectedOutput, out)
 		}
 	})
 }

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -77,18 +77,18 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crdName},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 	})
-	logger.Section("deploying with --warnings flag", func() {
+	logger.Section("deploying without --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-1", 1)
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=true"},
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 
 		if !strings.Contains(out, customWarning) {
 			t.Fatalf("Expected warning %s, but didn't get", customWarning)
 		}
 	})
-	logger.Section("deploying without --warnings flag", func() {
+	logger.Section("deploying with --warnings flag", func() {
 		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName},
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName, "--warnings=false"},
 			RunOpts{StdinReader: strings.NewReader(yaml)})
 
 		if strings.Contains(out, customWarning) {


### PR DESCRIPTION
Changes:
- `deps_factory.go` now has a function which returns a `DynamicClient` which does not produce warnings. Called `MutedDynamicClient`.
- The `ResourcesImpl` now has a `MutedDynamicClient` , `NewResourcesImpl()` and all references updated accordingly.
- `All()` in `resources.go` uses a `MutedDynamicClient` to make API calls.
