### PR TITLE
Update error message for invalid change rule annotation values

### DIFF
--- a/pkg/kapp/diffgraph/change.go
+++ b/pkg/kapp/diffgraph/change.go
@@ -141,7 +141,7 @@ func (c *Change) AllRules() ([]ChangeRule, error) {
 		if k == changeRuleAnnKey || strings.HasPrefix(k, changeRuleAnnPrefixKey) {
 			rule, err := NewChangeRuleFromAnnString(v)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("Resource %s: %s", res.Description(), err)
 			}
 			rules = append(rules, rule)
 		}
@@ -154,7 +154,7 @@ func (c *Change) AllRules() ([]ChangeRule, error) {
 			for _, ruleStr := range ruleConfig.Rules {
 				rule, err := NewChangeRuleFromAnnString(ruleStr)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("Resource %s: %s", res.Description(), err)
 				}
 				rule.IgnoreIfCyclical = ruleConfig.IgnoreIfCyclical
 				rule.weight = 100 + i // start at 100

--- a/pkg/kapp/diffgraph/change_rule.go
+++ b/pkg/kapp/diffgraph/change_rule.go
@@ -38,7 +38,7 @@ func NewChangeRuleFromAnnString(ann string) (ChangeRule, error) {
 	pieces := strings.Split(ann, " ")
 	if len(pieces) != 4 {
 		return ChangeRule{}, fmt.Errorf(
-			"Expected change rule annotation value to have 4 pieces but was %d", len(pieces))
+			"Expected change rule annotation value to have format '(upsert|delete) (before|after) (upserting|deleting) (change-group)', but was '%s'", ann)
 	}
 
 	rule := ChangeRule{


### PR DESCRIPTION
Update the error message which is shown when change rule annotation value has wrong number of arguments/pieces. The message should be more descriptive and provide a better idea of the format.