### PR TITLE
Add 'versioned-explicit-ref' annotation

### DIFF
--- a/pkg/kapp/diff/explicit_versioned_ref.go
+++ b/pkg/kapp/diff/explicit_versioned_ref.go
@@ -1,0 +1,90 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package diff
+
+import (
+	"fmt"
+)
+
+type VersionedRefDesc struct {
+	Namespace string `json:"namespace"`
+	APIGroup  string `json:"apiGroup"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+}
+
+type ExplicitVersionedRefAnn struct {
+	References     []VersionedRefDesc `json:"references"`
+	VersionedNames map[string]string
+}
+
+type ExplicitVersionedRef struct {
+	Resource   VersionedResource
+	Annotation ExplicitVersionedRefAnn
+}
+
+const (
+	explicitReferenceKey = "kapp.k14s.io/versioned-explicit-ref"
+)
+
+func NewExplicitVersionedRef(res VersionedResource, annotation ExplicitVersionedRefAnn) *ExplicitVersionedRef {
+	return &ExplicitVersionedRef{res, annotation}
+}
+
+// Returns true if the
+func (e *ExplicitVersionedRef) IsReferenced() (bool, error) {
+	references, err := e.refStringList()
+	if err != nil {
+		return false, err
+	}
+
+	referenceKey := e.resourceRefString()
+
+	for _, v := range references {
+		if v == referenceKey {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (e *ExplicitVersionedRef) refStringList() ([]string, error) {
+	list := []string{}
+	for _, v := range e.Annotation.References {
+		v, err := e.validateAndReplaceCoreGroup(v)
+		if err != nil {
+			return list, err
+		}
+
+		list = append(list, fmt.Sprintf("%s/%s/%s/%s", v.Namespace, v.APIGroup, v.Kind, v.Name))
+	}
+	return list, nil
+}
+
+func (e *ExplicitVersionedRef) validateAndReplaceCoreGroup(resourceDescription VersionedRefDesc) (VersionedRefDesc, error) {
+	// Replacing APIGroup value "core" with an empty string
+	// Edgecase for resources that are a part of "core"
+	if resourceDescription.APIGroup == "core" {
+		resourceDescription.APIGroup = ""
+	}
+
+	if resourceDescription.Kind == "" || resourceDescription.Name == "" {
+		return resourceDescription, fmt.Errorf("Explicit Reference Error: Name and Kind are required values in an explicit reference")
+	}
+	return resourceDescription, nil
+}
+
+func (e *ExplicitVersionedRef) resourceRefString() string {
+	return e.Resource.UniqVersionedKey().String()
+}
+
+/*
+Annotation with a list of references in JSON format:
+
+kapp.k14s.io/versioned-explicit-ref: '{ "references": [ { "namespace": <resource-namespace>, "apiGroup":  <resource-apiGroup>, "kind" : <resource-kind>, "name":  <resource-name> } ] }'
+
+"namespace" need not be assigned a value for cluster-scoped resources.
+"apiGroup" need not be assigned a value for resources belonging to "core" API group.
+*/

--- a/pkg/kapp/diff/explicit_versioned_ref.go
+++ b/pkg/kapp/diff/explicit_versioned_ref.go
@@ -32,14 +32,14 @@ func NewExplicitVersionedRef(res VersionedResource, annotation ExplicitVersioned
 	return &ExplicitVersionedRef{res, annotation}
 }
 
-// Returns true if the
+// Returns true if the resource is referenced by the annotation
 func (e *ExplicitVersionedRef) IsReferenced() (bool, error) {
-	references, err := e.refStringList()
+	references, err := e.references()
 	if err != nil {
 		return false, err
 	}
 
-	referenceKey := e.resourceRefString()
+	referenceKey := e.referenceKey()
 
 	for _, v := range references {
 		if v == referenceKey {
@@ -50,7 +50,7 @@ func (e *ExplicitVersionedRef) IsReferenced() (bool, error) {
 	return false, nil
 }
 
-func (e *ExplicitVersionedRef) refStringList() ([]string, error) {
+func (e *ExplicitVersionedRef) references() ([]string, error) {
 	list := []string{}
 	for _, v := range e.Annotation.References {
 		v, err := e.validateAndReplaceCoreGroup(v)
@@ -76,7 +76,7 @@ func (e *ExplicitVersionedRef) validateAndReplaceCoreGroup(resourceDescription V
 	return resourceDescription, nil
 }
 
-func (e *ExplicitVersionedRef) resourceRefString() string {
+func (e *ExplicitVersionedRef) referenceKey() string {
 	return e.Resource.UniqVersionedKey().String()
 }
 

--- a/pkg/kapp/diff/versioned_resource.go
+++ b/pkg/kapp/diff/versioned_resource.go
@@ -94,35 +94,32 @@ func (d VersionedResource) updateAffected(rule ctlconf.TemplateRule, rs []ctlres
 	for _, res := range rs {
 		for k, v := range res.Annotations() {
 			if k == explicitReferenceKey || strings.HasPrefix(k, explicitReferenceKeyPrefix) {
-				explicitRef := NewExplicitVersionedRef(d, v)
-				isReferenced, err := explicitRef.IsReferenced()
+				explicitRef := NewExplicitVersionedRef(k, v)
+				objectRef, err := explicitRef.AsObjectRef()
 				if err != nil {
-					return err
+					return fmt.Errorf("Parsing versioned explicit ref on resource '%s': %s", res.Description(), err)
 				}
 
-				if isReferenced {
-					versionedReference, err := explicitRef.VersionedReference()
-					if err != nil {
-						return err
-					}
+				// Passing empty TemplateAffectedObjRef as explicit references do not have a special name key
+				err = d.buildObjRefReplacementFunc(ctlconf.TemplateAffectedObjRef{})(objectRef)
+				if err != nil {
+					return fmt.Errorf("Processing object ref for explicit ref on resource '%s': %s", res.Description(), err)
+				}
 
-					d.annotationMod(k, versionedReference).Apply(res)
+				annotationMod, err := explicitRef.AnnotationMod(objectRef)
+				if err != nil {
+					return fmt.Errorf("Preparing annotation mod for versioned explicit ref on resource '%s': %s", res.Description(), err)
+				}
+
+				err = annotationMod.Apply(res)
+				if err != nil {
+					return fmt.Errorf("Updating versioned explicit ref on resource '%s': %s", res.Description(), err)
 				}
 			}
 		}
 	}
 
 	return nil
-}
-
-func (d VersionedResource) annotationMod(annotation string, value string) ctlres.StringMapAppendMod {
-	return ctlres.StringMapAppendMod{
-		ResourceMatcher: ctlres.AllMatcher{},
-		Path:            ctlres.NewPathFromStrings([]string{"metadata", "annotations"}),
-		KVs: map[string]string{
-			annotation: value,
-		},
-	}
 }
 
 func (d VersionedResource) buildObjRefReplacementFunc(

--- a/pkg/kapp/diff/versioned_resource.go
+++ b/pkg/kapp/diff/versioned_resource.go
@@ -97,12 +97,12 @@ func (d VersionedResource) updateAffected(rule ctlconf.TemplateRule, rs []ctlres
 					return fmt.Errorf("Error unmarshalling explicit references : %s", err)
 				}
 
-				isTarget, err := NewExplicitVersionedRef(d, annotation).IsReferenced()
+				isReferenced, err := NewExplicitVersionedRef(d, annotation).IsReferenced()
 				if err != nil {
 					return err
 				}
 
-				if isTarget {
+				if isReferenced {
 					if annotation.VersionedNames == nil {
 						annotation.VersionedNames = map[string]string{}
 					}

--- a/test/e2e/versioned_explicit_reference_test.go
+++ b/test/e2e/versioned_explicit_reference_test.go
@@ -32,7 +32,11 @@ kind: ConfigMap
 metadata:
   name: config-2
   annotations:
-    kapp.k14s.io/versioned-explicit-ref: '{ "references": [ { "namespace": "kapp-test", "kind" : "ConfigMap", "name": "config-1"} ] }'
+    kapp.k14s.io/versioned-explicit-ref: |
+      namespace: kapp-test
+      apiVersion: v1
+      kind: ConfigMap
+      name: config-1
 data:
   foo: bar
 `
@@ -53,7 +57,11 @@ kind: ConfigMap
 metadata:
   name: config-2
   annotations:
-    kapp.k14s.io/versioned-explicit-ref: '{ "references": [ { "namespace": "kapp-test", "kind" : "ConfigMap", "name": "config-1"} ] }'
+    kapp.k14s.io/versioned-explicit-ref: |
+      namespace: kapp-test
+      apiVersion: v1
+      kind: ConfigMap
+      name: config-1
 data:
   foo: bar
 `

--- a/test/e2e/versioned_explicit_reference_test.go
+++ b/test/e2e/versioned_explicit_reference_test.go
@@ -1,0 +1,107 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+)
+
+func TestVersionedExplicitReference(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	yaml1 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-1
+  annotations:
+    kapp.k14s.io/versioned: ""
+data:
+  foo: bar
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-2
+  annotations:
+    kapp.k14s.io/versioned-explicit-ref: '{ "references": [ { "namespace": "kapp-test", "kind" : "ConfigMap", "name": "config-1"} ] }'
+data:
+  foo: bar
+`
+
+	yaml2 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-1
+  annotations:
+    kapp.k14s.io/versioned: ""
+data:
+  foo: alpha
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-2
+  annotations:
+    kapp.k14s.io/versioned-explicit-ref: '{ "references": [ { "namespace": "kapp-test", "kind" : "ConfigMap", "name": "config-1"} ] }'
+data:
+  foo: bar
+`
+
+	name := "test-versioned-explicit-references"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy initial", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+	})
+
+	logger.Section("update versioned resource", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+		resp := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expected := []map[string]string{{
+			"age":             "",
+			"conditions":      "",
+			"kind":            "ConfigMap",
+			"name":            "config-1-ver-2",
+			"namespace":       "kapp-test",
+			"op":              "create",
+			"op_strategy":     "",
+			"reconcile_info":  "",
+			"reconcile_state": "",
+			"wait_to":         "reconcile",
+		}, {
+			"age":             "<replaced>",
+			"conditions":      "",
+			"kind":            "ConfigMap",
+			"name":            "config-2",
+			"namespace":       "kapp-test",
+			"op":              "update",
+			"op_strategy":     "",
+			"reconcile_info":  "",
+			"reconcile_state": "ok",
+			"wait_to":         "reconcile",
+		}}
+
+		if !reflect.DeepEqual(replaceAge(resp.Tables[0].Rows), expected) {
+			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
+		}
+	})
+}


### PR DESCRIPTION
Synthetic reference to a versioned resource.
For example: 
```yaml
kapp.k14s.io/versioned-explicit-ref: |
    apiVersion: v1
    kind: Secret
    name: root-password
```
The value of the key `name` is to be replaced by the latest versioned name of the referred resource
Pending:
- [x]  E2E tests