### PR TITLE
add --dangerous-scope-to-fallback-allowed-namespaces

### DIFF
--- a/pkg/kapp/cmd/app/factory.go
+++ b/pkg/kapp/cmd/app/factory.go
@@ -36,17 +36,21 @@ func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFl
 		return FactorySupportObjs{}, err
 	}
 
-	fallbackAllowedNss := []string{nsFlags.Name}
-
 	resTypes := ctlres.NewResourceTypesImpl(coreClient, ctlres.ResourceTypesImplOpts{
 		IgnoreFailingAPIServices:   resTypesFlags.IgnoreFailingAPIServices,
 		CanIgnoreFailingAPIService: resTypesFlags.CanIgnoreFailingAPIService,
 	})
 
-	resources := ctlres.NewResourcesImpl(resTypes, coreClient, dynamicClient, mutedDynamicClient, fallbackAllowedNss, logger)
+	resourcesImplOpts := ctlres.ResourcesImplOpts{
+		FallbackAllowedNamespaces:        []string{nsFlags.Name},
+		ScopeToFallbackAllowedNamespaces: resTypesFlags.ScopeToFallbackAllowedNamespaces,
+	}
+
+	resources := ctlres.NewResourcesImpl(
+		resTypes, coreClient, dynamicClient, mutedDynamicClient, resourcesImplOpts, logger)
 
 	identifiedResources := ctlres.NewIdentifiedResources(
-		coreClient, resTypes, resources, fallbackAllowedNss, logger)
+		coreClient, resTypes, resources, resourcesImplOpts.FallbackAllowedNamespaces, logger)
 
 	result := FactorySupportObjs{
 		CoreClient:          coreClient,

--- a/pkg/kapp/cmd/app/resource_types_flags.go
+++ b/pkg/kapp/cmd/app/resource_types_flags.go
@@ -11,11 +11,16 @@ import (
 type ResourceTypesFlags struct {
 	IgnoreFailingAPIServices   bool
 	CanIgnoreFailingAPIService func(schema.GroupVersion) bool
+
+	ScopeToFallbackAllowedNamespaces bool
 }
 
 func (s *ResourceTypesFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&s.IgnoreFailingAPIServices, "dangerous-ignore-failing-api-services",
 		false, "Allow to ignore failing APIServices")
+
+	cmd.Flags().BoolVar(&s.ScopeToFallbackAllowedNamespaces, "dangerous-scope-to-fallback-allowed-namespaces",
+		false, "Scope resource searching to fallback allowed namespaces")
 }
 
 func (s *ResourceTypesFlags) FailingAPIServicePolicy() *FailingAPIServicesPolicy {

--- a/pkg/kapp/cmd/tools/list_labels.go
+++ b/pkg/kapp/cmd/tools/list_labels.go
@@ -133,7 +133,8 @@ func (o *ListLabelsOptions) listResources() ([]ctlres.Resource, error) {
 	}
 
 	resTypes := ctlres.NewResourceTypesImpl(coreClient, ctlres.ResourceTypesImplOpts{})
-	resources := ctlres.NewResourcesImpl(resTypes, coreClient, dynamicClient, mutedDynamicClient, nil, o.logger)
+	resources := ctlres.NewResourcesImpl(
+		resTypes, coreClient, dynamicClient, mutedDynamicClient, ctlres.ResourcesImplOpts{}, o.logger)
 	identifiedResources := ctlres.NewIdentifiedResources(coreClient, resTypes, resources, nil, o.logger)
 
 	labelSelector, err := labels.Parse("!kapp")

--- a/pkg/kapp/resources/resources.go
+++ b/pkg/kapp/resources/resources.go
@@ -524,8 +524,10 @@ func (c *ResourcesImpl) assumedAllowedNamespaces() ([]string, error) {
 				return c.fallbackAllowedNamespaces, nil
 			}
 		}
-		return nil, fmt.Errorf("fetching all namespaces: %s", err)
+		return nil, fmt.Errorf("Fetching all namespaces: %s", err)
 	}
+
+	c.logger.Info("Falled back to checking each namespace separately (much slower)")
 
 	var nsNames []string
 

--- a/pkg/kapp/resources/resources.go
+++ b/pkg/kapp/resources/resources.go
@@ -53,11 +53,11 @@ type ExistsOpts struct {
 }
 
 type ResourcesImpl struct {
-	resourceTypes             ResourceTypes
-	coreClient                kubernetes.Interface
-	dynamicClient             dynamic.Interface
-	mutedDynamicClient        dynamic.Interface
-	fallbackAllowedNamespaces []string
+	resourceTypes      ResourceTypes
+	coreClient         kubernetes.Interface
+	dynamicClient      dynamic.Interface
+	mutedDynamicClient dynamic.Interface
+	opts               ResourcesImplOpts
 
 	assumedAllowedNamespacesMemoLock sync.Mutex
 	assumedAllowedNamespacesMemo     *[]string
@@ -65,17 +65,22 @@ type ResourcesImpl struct {
 	logger logger.Logger
 }
 
+type ResourcesImplOpts struct {
+	FallbackAllowedNamespaces        []string
+	ScopeToFallbackAllowedNamespaces bool
+}
+
 func NewResourcesImpl(resourceTypes ResourceTypes, coreClient kubernetes.Interface,
 	dynamicClient dynamic.Interface, mutedDynamicClient dynamic.Interface,
-	fallbackAllowedNamespaces []string, logger logger.Logger) *ResourcesImpl {
+	opts ResourcesImplOpts, logger logger.Logger) *ResourcesImpl {
 
 	return &ResourcesImpl{
-		resourceTypes:             resourceTypes,
-		coreClient:                coreClient,
-		dynamicClient:             dynamicClient,
-		mutedDynamicClient:        mutedDynamicClient,
-		fallbackAllowedNamespaces: fallbackAllowedNamespaces,
-		logger:                    logger.NewPrefixed("Resources"),
+		resourceTypes:      resourceTypes,
+		coreClient:         coreClient,
+		dynamicClient:      dynamicClient,
+		mutedDynamicClient: mutedDynamicClient,
+		opts:               opts,
+		logger:             logger.NewPrefixed("Resources"),
 	}
 }
 
@@ -91,8 +96,17 @@ func (c *ResourcesImpl) All(resTypes []ResourceType, opts AllOpts) ([]Resource, 
 		opts.ListOpts = &metav1.ListOptions{}
 	}
 
+	nsScope := "" // all namespaces by default
+	nsScopeLimited := c.opts.ScopeToFallbackAllowedNamespaces && len(c.opts.FallbackAllowedNamespaces) == 1
+
+	// Eagerly use single fallback namespace to avoid making all-namespaces request
+	// just to see it fail, and fallback to making namespace-scoped request
+	if nsScopeLimited {
+		nsScope = c.opts.FallbackAllowedNamespaces[0]
+		c.logger.Info("Scoping listings to single namespace: %s", nsScope)
+	}
+
 	unstructItemsCh := make(chan unstructItems, len(resTypes))
-	warnErrsCh := make(chan error, len(resTypes))
 	fatalErrsCh := make(chan error, len(resTypes))
 	var itemsDone sync.WaitGroup
 
@@ -112,7 +126,7 @@ func (c *ResourcesImpl) All(resTypes []ResourceType, opts AllOpts) ([]Resource, 
 
 			err = util.Retry2(time.Second, 5*time.Second, c.isServerRescaleErr, func() error {
 				if resType.Namespaced() {
-					list, err = client.Namespace("").List(context.TODO(), *opts.ListOpts)
+					list, err = client.Namespace(nsScope).List(context.TODO(), *opts.ListOpts)
 				} else {
 					list, err = client.List(context.TODO(), *opts.ListOpts)
 				}
@@ -123,15 +137,19 @@ func (c *ResourcesImpl) All(resTypes []ResourceType, opts AllOpts) ([]Resource, 
 				if !errors.IsForbidden(err) {
 					// Ignore certain GVs due to failing API backing
 					if c.resourceTypes.CanIgnoreFailingGroupVersion(resType.GroupVersion()) {
-						c.logger.Info("Ignoring group version: %#v", resType.GroupVersionResource)
+						c.logger.Info("Ignoring group version: %#v: %s", resType.GroupVersionResource, err)
 					} else {
 						fatalErrsCh <- fmt.Errorf("Listing %#v, namespaced: %t: %s", resType.GroupVersionResource, resType.Namespaced(), err)
 					}
 					return
 				}
+				// At this point err==Forbidden...
 
-				if !resType.Namespaced() {
-					warnErrsCh <- fmt.Errorf("Listing %#v, namespaced: %t: %s", resType.GroupVersionResource, resType.Namespaced(), err)
+				// In case ns scope is limited already, we will not gain anything
+				// by trying to run namespace scoped lists for allowed namespaced
+				// (ie since it's would be same request that just failed)
+				if !resType.Namespaced() || nsScopeLimited {
+					c.logger.Debug("Skipping forbidden group version: %#v", resType.GroupVersionResource)
 					return
 				}
 
@@ -154,7 +172,6 @@ func (c *ResourcesImpl) All(resTypes []ResourceType, opts AllOpts) ([]Resource, 
 
 	itemsDone.Wait()
 	close(unstructItemsCh)
-	close(warnErrsCh)
 	close(fatalErrsCh)
 
 	for err := range fatalErrsCh {
@@ -197,6 +214,8 @@ func (c *ResourcesImpl) allForNamespaces(client dynamic.NamespaceableResourceInt
 					fatalErrsCh <- err
 					return
 				}
+				// Ignore forbidden errors
+				// TODO somehow surface them
 			} else {
 				unstructItemsCh <- resList
 			}
@@ -520,14 +539,14 @@ func (c *ResourcesImpl) assumedAllowedNamespaces() ([]string, error) {
 	nsList, err := c.coreClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if errors.IsForbidden(err) {
-			if len(c.fallbackAllowedNamespaces) > 0 {
-				return c.fallbackAllowedNamespaces, nil
+			if len(c.opts.FallbackAllowedNamespaces) > 0 {
+				return c.opts.FallbackAllowedNamespaces, nil
 			}
 		}
 		return nil, fmt.Errorf("Fetching all namespaces: %s", err)
 	}
 
-	c.logger.Info("Falled back to checking each namespace separately (much slower)")
+	c.logger.Info("Falling back to checking each namespace separately (much slower)")
 
 	var nsNames []string
 


### PR DESCRIPTION
this is useful to force kapp only look within a fallback-allowed-namespace -- and in case there is only 1 ns (currently that's the case), it eliminates a lot list requests when running under a service account that has access to list all namespaces, but does not have access to list resources within those namespaces.