### PR TITLE
[draft] Added --dry-run flag

### DIFF
--- a/pkg/kapp/clusterapply/cluster_change.go
+++ b/pkg/kapp/clusterapply/cluster_change.go
@@ -100,7 +100,7 @@ func (c *ClusterChange) ApplyOp() ClusterChangeApplyOp {
 }
 
 func (c *ClusterChange) WaitOp() ClusterChangeWaitOp {
-	if !c.opts.Wait {
+	if !c.opts.Wait || c.opts.DryRun {
 		return ClusterChangeWaitOpNoop
 	}
 

--- a/pkg/kapp/cmd/app/apply_flags.go
+++ b/pkg/kapp/cmd/app/apply_flags.go
@@ -49,6 +49,7 @@ func (s *ApplyFlags) SetWithDefaults(prefix string, defaults ApplyFlags, cmd *co
 
 	cmd.Flags().StringVar(&s.AddOrUpdateChangeOpts.DefaultUpdateStrategy, prefix+"apply-default-update-strategy",
 		defaults.AddOrUpdateChangeOpts.DefaultUpdateStrategy, "Change default update strategy")
+	cmd.Flags().BoolVar(&s.AddOrUpdateChangeOpts.DryRun, prefix+"dry-run", false, "Execute a server side dry run without persisting changes on the cluster")
 
 	cmd.Flags().BoolVar(&s.Wait, prefix+"wait", defaults.Wait, "Set to wait for changes to be applied")
 	cmd.Flags().BoolVar(&s.WaitIgnored, prefix+"wait-ignored", defaults.WaitIgnored, "Set to wait for ignored changes to be applied")

--- a/pkg/kapp/cmd/app/delete.go
+++ b/pkg/kapp/cmd/app/delete.go
@@ -59,6 +59,8 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 func (o *DeleteOptions) Run() error {
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
+	o.ResourceTypesFlags.DryRun = o.ApplyFlags.DryRun
+
 	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
 	if err != nil {
 		return err

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -85,6 +85,8 @@ func NewDeployCmd(o *DeployOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 func (o *DeployOptions) Run() error {
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
+	o.ResourceTypesFlags.DryRun = o.ApplyFlags.DryRun
+
 	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
 	if err != nil {
 		return err

--- a/pkg/kapp/cmd/app/factory.go
+++ b/pkg/kapp/cmd/app/factory.go
@@ -44,6 +44,7 @@ func FactoryClients(depsFactory cmdcore.DepsFactory, nsFlags cmdcore.NamespaceFl
 	resourcesImplOpts := ctlres.ResourcesImplOpts{
 		FallbackAllowedNamespaces:        []string{nsFlags.Name},
 		ScopeToFallbackAllowedNamespaces: resTypesFlags.ScopeToFallbackAllowedNamespaces,
+		DryRun:                           resTypesFlags.DryRun,
 	}
 
 	resources := ctlres.NewResourcesImpl(

--- a/pkg/kapp/cmd/app/resource_types_flags.go
+++ b/pkg/kapp/cmd/app/resource_types_flags.go
@@ -13,6 +13,8 @@ type ResourceTypesFlags struct {
 	CanIgnoreFailingAPIService func(schema.GroupVersion) bool
 
 	ScopeToFallbackAllowedNamespaces bool
+
+	DryRun bool
 }
 
 func (s *ResourceTypesFlags) Set(cmd *cobra.Command) {

--- a/pkg/kapp/cmd/appgroup/delete.go
+++ b/pkg/kapp/cmd/appgroup/delete.go
@@ -54,7 +54,10 @@ func (o *DeleteOptions) Run() error {
 		return fmt.Errorf("Expected group name to be non-empty")
 	}
 
-	supportObjs, err := cmdapp.FactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	resTypesFlags := cmdapp.ResourceTypesFlags{
+		DryRun: o.AppFlags.ApplyFlags.AddOrUpdateChangeOpts.DryRun,
+	}
+	supportObjs, err := cmdapp.FactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, resTypesFlags, o.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -82,7 +82,10 @@ func (o *DeployOptions) Run() error {
 		}
 	}
 
-	supportObjs, err := cmdapp.FactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, cmdapp.ResourceTypesFlags{}, o.logger)
+	resTypesFlags := cmdapp.ResourceTypesFlags{
+		DryRun: o.AppFlags.ApplyFlags.AddOrUpdateChangeOpts.DryRun,
+	}
+	supportObjs, err := cmdapp.FactoryClients(o.depsFactory, o.AppGroupFlags.NamespaceFlags, resTypesFlags, o.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Setting the `DryRun` option for k8s API calls if `--dry-run` is used
- Not waiting for reconciliation if `--dry-run` is used