### PR TITLE
Update tests to use testify/require instead of value comparisons and Fatal

### DIFF
--- a/pkg/kapp/diff/change_set_test.go
+++ b/pkg/kapp/diff/change_set_test.go
@@ -9,6 +9,7 @@ import (
 
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChangeSet_RebaseWithoutNew_And_WithUnexpectedChanges(t *testing.T) {
@@ -52,9 +53,7 @@ metadata:
 		ctldiff.ChangeSetOpts{}, changeFactory)
 
 	changes, err := changeSet.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-err")
-	}
+	require.NoError(t, err)
 
 	actualDiff := changes[0].ConfigurableTextDiff().Full().FullString()
 
@@ -66,9 +65,7 @@ metadata:
   5,  4   <---space
 `, "<---space", "", -1)
 
-	if actualDiff != expectedDiff {
-		t.Fatalf("Expected diff to match: actual >>>%s<<< vs expected >>>%s<<< %d %d", actualDiff, expectedDiff, len(actualDiff), len(expectedDiff))
-	}
+	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
 }
 
 func TestChangeSet_RebaseWithNew_And_UnexpectedChanges(t *testing.T) {
@@ -114,9 +111,7 @@ metadata:
 		ctldiff.ChangeSetOpts{}, changeFactory)
 
 	changes, err := changeSet.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-err")
-	}
+	require.NoError(t, err)
 
 	actualDiff := changes[0].ConfigurableTextDiff().Full().FullString()
 
@@ -129,9 +124,7 @@ metadata:
   5,  5   <---space
 `, "<---space", "", -1)
 
-	if actualDiff != expectedDiff {
-		t.Fatalf("Expected diff to match: actual >>>%s<<< vs expected >>>%s<<< %d %d", actualDiff, expectedDiff, len(actualDiff), len(expectedDiff))
-	}
+	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
 }
 
 func TestChangeSet_WithoutNew_And_WithoutUnexpectedChanges_And_IgnoredFields(t *testing.T) {
@@ -186,9 +179,7 @@ metadata:
 		ctldiff.ChangeSetOpts{AgainstLastApplied: true}, changeFactory)
 
 	changes, err := changeSet.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-err")
-	}
+	require.NoError(t, err)
 
 	actualDiff := changes[0].ConfigurableTextDiff().Full().FullString()
 
@@ -199,9 +190,7 @@ metadata:
   4,  4   <---space
 `, "<---space", "", -1)
 
-	if actualDiff != expectedDiff {
-		t.Fatalf("Expected diff to match: actual >>>%s<<< vs expected >>>%s<<< %d %d", actualDiff, expectedDiff, len(actualDiff), len(expectedDiff))
-	}
+	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
 }
 
 func TestChangeSet_WithoutNew_And_WithUnexpectedChanges_And_IgnoredFields(t *testing.T) {
@@ -262,9 +251,7 @@ metadata:
 		ctldiff.ChangeSetOpts{AgainstLastApplied: true}, changeFactory)
 
 	changes, err := changeSet.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-err")
-	}
+	require.NoError(t, err)
 
 	actualDiff := changes[0].ConfigurableTextDiff().Full().FullString()
 
@@ -277,7 +264,5 @@ metadata:
   6,  5   <---space
 `, "<---space", "", -1)
 
-	if actualDiff != expectedDiff {
-		t.Fatalf("Expected diff to match: actual >>>%s<<< vs expected >>>%s<<< %d %d", actualDiff, expectedDiff, len(actualDiff), len(expectedDiff))
-	}
+	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
 }

--- a/pkg/kapp/diff/change_set_with_versioned_rs_test.go
+++ b/pkg/kapp/diff/change_set_with_versioned_rs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChangeSet_ExistingVersioned_NewNonVersioned_Resource(t *testing.T) {
@@ -30,21 +31,13 @@ metadata:
 		ChangeSetOpts{}, ChangeFactory{})
 
 	changes, err := changeSetWithVerRes.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-error")
-	}
+	require.NoError(t, err)
 
-	if len(changes) != 2 {
-		t.Fatalf("Expected length of changes list is 2")
-	}
+	require.Len(t, changes, 2)
 
-	if changes[0].Op() != ChangeOpDelete {
-		t.Fatalf("Expected to get deleted: actual >>>%s<<< vs expected >>>%s<<<", changes[0].Op(), ChangeOpDelete)
-	}
+	require.Equal(t, ChangeOpDelete, changes[0].Op(), "Expected to get deleted")
 
-	if changes[1].Op() != ChangeOpAdd {
-		t.Fatalf("Expected to get added: actual >>>%s<<< vs expected >>>%s<<<", changes[1].Op(), ChangeOpAdd)
-	}
+	require.Equal(t, ChangeOpAdd, changes[1].Op(), "Expected to get added")
 
 	expectedDiff1 := `  0,  0 - apiVersion: v1
   1,  0 - kind: Secret
@@ -86,21 +79,13 @@ metadata:
 		ChangeSetOpts{}, ChangeFactory{})
 
 	changes, err := changeSetWithVerRes.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-error")
-	}
+	require.NoError(t, err)
 
-	if len(changes) != 2 {
-		t.Fatalf("Expected length of changes list is 2")
-	}
+	require.Len(t, changes, 2)
 
-	if changes[0].Op() != ChangeOpAdd {
-		t.Fatalf("Expected to get added: actual >>>%s<<< vs expected >>>%s<<<", changes[0].Op(), ChangeOpAdd)
-	}
+	require.Equal(t, ChangeOpAdd, changes[0].Op(), "Expected to get added")
 
-	if changes[1].Op() != ChangeOpDelete {
-		t.Fatalf("Expected to get deleted: actual >>>%s<<< vs expected >>>%s<<<", changes[1].Op(), ChangeOpDelete)
-	}
+	require.Equal(t, ChangeOpDelete, changes[1].Op(), "Expected to get deleted")
 
 	expectedDiff1 := `  0,  0 + apiVersion: v1
   0,  1 + kind: Secret
@@ -143,21 +128,13 @@ metadata:
 		ChangeSetOpts{}, ChangeFactory{})
 
 	changes, err := changeSetWithVerRes.Calculate()
-	if err != nil {
-		t.Fatalf("Expected non-error")
-	}
+	require.NoError(t, err)
 
-	if len(changes) != 2 {
-		t.Fatalf("Expected length of changes list is 2")
-	}
+	require.Len(t, changes, 2)
 
-	if changes[0].Op() != ChangeOpAdd {
-		t.Fatalf("Expected to get added: actual >>>%s<<< vs expected >>>%s<<<", changes[0].Op(), ChangeOpAdd)
-	}
+	require.Equal(t, ChangeOpAdd, changes[0].Op(), "Expected to get added")
 
-	if changes[1].Op() != ChangeOpUpdate {
-		t.Fatalf("Expected to get updated: actual >>>%s<<< vs expected >>>%s<<<", changes[1].Op(), ChangeOpUpdate)
-	}
+	require.Equal(t, ChangeOpUpdate, changes[1].Op(), "Expected to get updated")
 
 	expectedDiff1 := `  0,  0 + apiVersion: v1
   0,  1 + kind: Secret
@@ -185,8 +162,5 @@ metadata:
 func checkChangeDiff(t *testing.T, change Change, expectedDiff string) {
 	actualDiffString := change.ConfigurableTextDiff().Full().FullString()
 
-	if actualDiffString != expectedDiff {
-		t.Fatalf("Expected diff to match: actual >>>%s<<< vs expected >>>%s<<< %d %d",
-			actualDiffString, expectedDiff, len(actualDiffString), len(expectedDiff))
-	}
+	require.Equal(t, expectedDiff, actualDiffString, "Expected diff to match")
 }


### PR DESCRIPTION
Update all tests to use testify/require instead value comparisons and Fatal() as it's more clean and provides error message in a more intuitive way.