### PR TITLE
Add verify-no-dirty-files check

### DIFF
--- a/.github/workflows/test-gh-k8s-1.16.yml
+++ b/.github/workflows/test-gh-k8s-1.16.yml
@@ -30,6 +30,8 @@ jobs:
           mkdir -p /tmp/bin
           export PATH=/tmp/bin:$PATH
 
+          ./hack/verify-no-dirty-files.sh
+
           wget -O- https://carvel.dev/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
           wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-linux-amd64 > /tmp/bin/minikube

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -30,6 +30,8 @@ jobs:
         mkdir -p /tmp/bin
         export PATH=/tmp/bin:$PATH
 
+        ./hack/verify-no-dirty-files.sh
+
         wget -O- https://carvel.dev/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
         curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/hack/verify-no-dirty-files.sh
+++ b/hack/verify-no-dirty-files.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+./hack/build.sh
+
+if ! git diff --exit-code >/dev/null; then
+  echo "Error: Running ./hack/build.sh resulted in non zero exit code from git diff. Please run './hack/build.sh' and 'git add' the generated file(s)."
+  echo "Showing diff:"
+  git diff --exit-code
+  exit 1
+fi


### PR DESCRIPTION
To mimic `kapp-controller`
Ensures that `go mod vendor; go mod tidy` does not lead to any uncommitted changes