### PR TITLE
Update tests to use testify/require

### DIFF
--- a/pkg/kapp/diffgraph/change_graph_cf_for_k8s_test.go
+++ b/pkg/kapp/diffgraph/change_graph_cf_for_k8s_test.go
@@ -12,23 +12,18 @@ import (
 	ctlconf "github.com/k14s/kapp/pkg/kapp/config"
 	ctldgraph "github.com/k14s/kapp/pkg/kapp/diffgraph"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChangeGraphCFForK8sUpsert(t *testing.T) {
 	configYAML, err := ioutil.ReadFile("assets/cf-for-k8s.yml")
-	if err != nil {
-		t.Fatalf("Reading cf-for-k8s asset: %s", err)
-	}
+	require.NoErrorf(t, err, "Reading cf-for-k8s asset")
 
 	configRs, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(configYAML))).Resources()
-	if err != nil {
-		t.Fatalf("Error parsing resources: %s", err)
-	}
+	require.NoErrorf(t, err, "Parsing resources")
 
 	rs, conf, err := ctlconf.NewConfFromResourcesWithDefaults(configRs)
-	if err != nil {
-		t.Fatalf("Error parsing conf defaults: %s", err)
-	}
+	require.NoErrorf(t, err, "Parsing conf defaults")
 
 	opts := buildGraphOpts{
 		resources:           rs,
@@ -40,37 +35,25 @@ func TestChangeGraphCFForK8sUpsert(t *testing.T) {
 	t1 := time.Now()
 
 	graph, err := buildChangeGraphWithOpts(opts, t)
-	if err != nil {
-		t.Fatalf("Expected graph to build: %s", err)
-	}
+	require.NoErrorf(t, err, "Expected graph to build")
 
-	if time.Now().Sub(t1) > time.Duration(1*time.Second) {
-		t.Fatalf("Graph build took too long")
-	}
+	require.Less(t, time.Now().Sub(t1), time.Duration(1*time.Second), "Graph build took too long")
 
 	output := strings.TrimSpace(graph.PrintLinearizedStr())
 	expectedOutput := strings.TrimSpace(cfForK8sExpectedOutputUpsert)
 
-	if output != expectedOutput {
-		t.Fatalf("Expected output to be >>>%s<<< but was >>>%s<<<", expectedOutput, output)
-	}
+	require.Equal(t, expectedOutput, output)
 }
 
 func TestChangeGraphCFForK8sDelete(t *testing.T) {
 	configYAML, err := ioutil.ReadFile("assets/cf-for-k8s.yml")
-	if err != nil {
-		t.Fatalf("Reading cf-for-k8s asset: %s", err)
-	}
+	require.NoErrorf(t, err, "Reading cf-for-k8s asset")
 
 	configRs, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(configYAML))).Resources()
-	if err != nil {
-		t.Fatalf("Error parsing resources: %s", err)
-	}
+	require.NoErrorf(t, err, "Parsing resources")
 
 	rs, conf, err := ctlconf.NewConfFromResourcesWithDefaults(configRs)
-	if err != nil {
-		t.Fatalf("Error parsing conf defaults: %s", err)
-	}
+	require.NoErrorf(t, err, "Parsing conf defaults")
 
 	opts := buildGraphOpts{
 		resources:           rs,
@@ -82,20 +65,14 @@ func TestChangeGraphCFForK8sDelete(t *testing.T) {
 	t1 := time.Now()
 
 	graph, err := buildChangeGraphWithOpts(opts, t)
-	if err != nil {
-		t.Fatalf("Expected graph to build: %s", err)
-	}
+	require.NoErrorf(t, err, "Expected graph to build")
 
-	if time.Now().Sub(t1) > time.Duration(1*time.Second) {
-		t.Fatalf("Graph build took too long")
-	}
+	require.Less(t, time.Now().Sub(t1), time.Duration(1*time.Second), "Graph build took too long")
 
 	output := strings.TrimSpace(graph.PrintLinearizedStr())
 	expectedOutput := strings.TrimSpace(cfForK8sExpectedOutputDelete)
 
-	if output != expectedOutput {
-		t.Fatalf("Expected output to be >>>%s<<< but was >>>%s<<<", expectedOutput, output)
-	}
+	require.Equal(t, expectedOutput, output)
 }
 
 const (

--- a/pkg/kapp/diffgraph/change_graph_optional_test.go
+++ b/pkg/kapp/diffgraph/change_graph_optional_test.go
@@ -10,6 +10,7 @@ import (
 	ctlconf "github.com/k14s/kapp/pkg/kapp/config"
 	ctldgraph "github.com/k14s/kapp/pkg/kapp/diffgraph"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChangeGraphWithAdditionalOrderRules(t *testing.T) {
@@ -43,9 +44,7 @@ changeRuleBindings:
 `
 
 	_, conf, err := ctlconf.NewConfFromResources([]ctlres.Resource{ctlres.MustNewResourceFromBytes([]byte(confYAML))})
-	if err != nil {
-		t.Fatalf("Expected parsing conf to succeed")
-	}
+	require.NoErrorf(t, err, "Expected parsing conf to succeed")
 
 	opts := buildGraphOpts{
 		resourcesBs:         configYAML,
@@ -55,9 +54,7 @@ changeRuleBindings:
 	}
 
 	graph, err := buildChangeGraphWithOpts(opts, t)
-	if err != nil {
-		t.Fatalf("Expected graph to build")
-	}
+	require.NoErrorf(t, err, "Expected graph to build")
 
 	output := strings.TrimSpace(graph.PrintStr())
 	expectedOutput := strings.TrimSpace(`
@@ -66,9 +63,7 @@ changeRuleBindings:
   (upsert) namespace/app1 (v1) cluster
 `)
 
-	if output != expectedOutput {
-		t.Fatalf("Expected output to be >>>%s<<< but was >>>%s<<<", expectedOutput, output)
-	}
+	require.Equal(t, expectedOutput, output)
 }
 
 func TestChangeGraphWithOptionalRulesThatProduceCycles(t *testing.T) {
@@ -126,9 +121,7 @@ changeRuleBindings:
 `
 
 	_, conf, err := ctlconf.NewConfFromResources([]ctlres.Resource{ctlres.MustNewResourceFromBytes([]byte(confYAML))})
-	if err != nil {
-		t.Fatalf("Expected parsing conf to succeed")
-	}
+	require.NoErrorf(t, err, "Expected parsing conf to succeed")
 
 	opts := buildGraphOpts{
 		resourcesBs:         configYAML,
@@ -138,9 +131,7 @@ changeRuleBindings:
 	}
 
 	graph, err := buildChangeGraphWithOpts(opts, t)
-	if err != nil {
-		t.Fatalf("Expected graph to build")
-	}
+	require.NoErrorf(t, err, "Expected graph to build")
 
 	output := strings.TrimSpace(graph.PrintStr())
 	expectedOutput := strings.TrimSpace(`
@@ -152,7 +143,5 @@ changeRuleBindings:
 (upsert) secret/app-config (v1) namespace: app1
 `)
 
-	if output != expectedOutput {
-		t.Fatalf("Expected output to be >>>%s<<< but was >>>%s<<<", expectedOutput, output)
-	}
+	require.Equal(t, expectedOutput, output)
 }

--- a/pkg/kapp/diffgraph/change_group_test.go
+++ b/pkg/kapp/diffgraph/change_group_test.go
@@ -29,7 +29,7 @@ func TestNewChangeGroupFromAnnString(t *testing.T) {
 	for _, name := range names {
 		cg, err := ctldgraph.NewChangeGroupFromAnnString(name)
 		require.NoError(t, err)
-		require.Equal(t, cg.Name, name)
+		require.Equal(t, name, cg.Name)
 	}
 
 	names = []string{

--- a/pkg/kapp/matcher/string_test.go
+++ b/pkg/kapp/matcher/string_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/k14s/kapp/pkg/kapp/matcher"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringMatcherMatches(t *testing.T) {
@@ -47,8 +48,5 @@ type stringMatcherExample struct {
 
 func (e stringMatcherExample) Check(t *testing.T) {
 	result := matcher.NewStringMatcher(e.Expected).Matches(e.Actual)
-	if result != e.Result {
-		t.Fatalf("Did not match result: expected=%s actual=%s wanted=%t got=%t",
-			e.Expected, e.Actual, e.Result, result)
-	}
+	require.Equal(t, e.Result, result, "Did not match result: expected=%s actual=%s", e.Expected, e.Actual)
 }


### PR DESCRIPTION
Update all tests in `pkg/kapp/diffgraph` and `pkg/kapp/matcher` to use testify/require instead value comparisons and Fatal() as it's more clean and provides error message in a more intuitive way

Issue #349