### PR TITLE
Update resources tests to use testify/require

### DIFF
--- a/pkg/kapp/resources/helpers_test.go
+++ b/pkg/kapp/resources/helpers_test.go
@@ -6,6 +6,8 @@ package resources_test
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func expectEqualsStripped(t *testing.T, description, resultStr, expectedStr string) {
@@ -13,8 +15,5 @@ func expectEqualsStripped(t *testing.T, description, resultStr, expectedStr stri
 }
 
 func expectEquals(t *testing.T, description, resultStr, expectedStr string) {
-	if resultStr != expectedStr {
-		t.Fatalf("%s: not equal\n\n### result %d chars:\n>>>%s<<<\n###expected %d chars:\n>>>%s<<<",
-			description, len(resultStr), resultStr, len(expectedStr), expectedStr)
-	}
+	require.Equal(t, expectedStr, resultStr, "%s: not equal", description)
 }

--- a/pkg/kapp/resources/mod_field_copy_test.go
+++ b/pkg/kapp/resources/mod_field_copy_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestModFieldCopy(t *testing.T) {
@@ -231,14 +232,10 @@ func (e modFieldCopyExample) Check(t *testing.T) {
 		Path:            e.Path,
 		Sources:         e.Sources,
 	}.ApplyFromMultiple(res, ress)
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	resultBs, err := res.AsYAMLBytes()
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	expectEqualsStripped(t, e.Description, string(resultBs), e.Expected)
 }

--- a/pkg/kapp/resources/mod_field_remove_test.go
+++ b/pkg/kapp/resources/mod_field_remove_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestModFieldRemove(t *testing.T) {
@@ -123,22 +124,16 @@ type modFieldRemoveExample struct {
 
 func (e modFieldRemoveExample) Check(t *testing.T) {
 	res, err := ctlres.NewResourceFromBytes([]byte(e.Res))
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	err = ctlres.FieldRemoveMod{
 		ResourceMatcher: ctlres.AllMatcher{},
 		Path:            e.Path,
 	}.Apply(res)
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	resultBs, err := res.AsYAMLBytes()
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	expectEqualsStripped(t, e.Description, string(resultBs), e.Expected)
 }

--- a/pkg/kapp/resources/mod_string_map_append_test.go
+++ b/pkg/kapp/resources/mod_string_map_append_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestModStringMapAppend(t *testing.T) {
@@ -168,23 +169,17 @@ type modStringMapAppendExample struct {
 
 func (e modStringMapAppendExample) Check(t *testing.T) {
 	res, err := ctlres.NewResourceFromBytes([]byte(e.Res))
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	err = ctlres.StringMapAppendMod{
 		ResourceMatcher: ctlres.AllMatcher{},
 		Path:            e.Path,
 		KVs:             e.KVs,
 	}.Apply(res)
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	resultBs, err := res.AsYAMLBytes()
-	if err != nil {
-		t.Fatalf("Expected no err, but was %s", err)
-	}
+	require.NoError(t, err)
 
 	expectEqualsStripped(t, e.Description, string(resultBs), e.Expected)
 }

--- a/pkg/kapp/resources/resource_test.go
+++ b/pkg/kapp/resources/resource_test.go
@@ -4,10 +4,10 @@
 package resources_test
 
 import (
-	"strings"
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompactBytesLength(t *testing.T) {
@@ -40,29 +40,18 @@ metadata:
 
 	// resource can be read from full repr
 	resFromFull, err := ctlres.NewResourceFromBytes([]byte(fullBs))
-	if err != nil {
-		t.Fatalf("Expected to parse full bytes: %s", err)
-	}
+	require.NoError(t, err, "Expected to parse full bytes")
 
 	compactBs, err := resFromFull.AsCompactBytes()
-	if err != nil {
-		t.Fatalf("Expected to produce compact bytes: %s", err)
-	}
+	require.NoError(t, err, "Expected to produce compact bytes")
 
 	// resource can be read from compact repr
 	resFromCompact, err := ctlres.NewResourceFromBytes([]byte(compactBs))
-	if err != nil {
-		t.Fatalf("Expected to parse compact bytes: %s", err)
-	}
+	require.NoError(t, err, "Expected to parse compact bytes")
 
-	if !resFromFull.Equal(resFromCompact) {
-		t.Fatalf("Expected resources to match: '%s' vs '%s'", fullBs, compactBs)
-	}
+	require.True(t, resFromFull.Equal(resFromCompact), "Expected resources to match: %q vs %q", fullBs, compactBs)
 
-	if len(compactBs) >= len(fullBs) {
-		t.Fatalf("Compact repr should be shorter than full repr: %d '%s' vs %d '%s'",
-			len(fullBs), fullBs, len(compactBs), compactBs)
-	}
+	require.Less(t, len(compactBs), len(fullBs), "Compact repr should be shorter than full repr")
 }
 
 func TestCompactBytesNoNewlinesForBetterFormatting(t *testing.T) {
@@ -80,19 +69,12 @@ metadata:
 `
 
 	resFromFull, err := ctlres.NewResourceFromBytes([]byte(fullBs))
-	if err != nil {
-		t.Fatalf("Expected to parse full bytes: %s", err)
-	}
+	require.NoError(t, err, "Expected to parse full bytes")
 
 	compactBs, err := resFromFull.AsCompactBytes()
-	if err != nil {
-		t.Fatalf("Expected to produce compact bytes: %s", err)
-	}
+	require.NoError(t, err, "Expected to produce compact bytes")
 
-	if !strings.Contains(string(fullBs), "\n") {
-		t.Fatalf("Expected full repr to have newlines: %s", fullBs)
-	}
-	if strings.Contains(string(compactBs), "\n") {
-		t.Fatalf("Expected compact repr to not have newlines: %s", compactBs)
-	}
+	require.Contains(t, string(fullBs), "\n", "Expected full repr to have newlines")
+
+	require.NotContains(t, string(compactBs), "\n", "Expected compact repr to not have newlines")
 }


### PR DESCRIPTION
Update all tests in `pkg/kapp/resources` to use `testify/require` instead of value comparisons and `Fatal()` as it's cleaner and provides error messages in a more intuitive way

Issue #349