### PR TITLE
Update tests to use testify/require

### DIFF
--- a/pkg/kapp/resourcesmisc/apps_v1_daemon_set_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_daemon_set_test.go
@@ -141,9 +141,7 @@ status:
 
 func buildDaemonSet(resourcesBs string, t *testing.T) *ctlresm.AppsV1DaemonSet {
 	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
-	if err != nil {
-		t.Fatalf("Expected resources to parse")
-	}
+	require.NoErrorf(t, err, "Expected resources to parse")
 
 	return ctlresm.NewAppsV1DaemonSet(newResources[0])
 }

--- a/pkg/kapp/resourcesmisc/apps_v1_daemon_set_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_daemon_set_test.go
@@ -4,11 +4,12 @@
 package resourcesmisc_test
 
 import (
+	"strings"
+	"testing"
+
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	ctlresm "github.com/k14s/kapp/pkg/kapp/resourcesmisc"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
 )
 
 func TestAppsV1DaemonSetCreation(t *testing.T) {

--- a/pkg/kapp/resourcesmisc/apps_v1_deployment_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_deployment_test.go
@@ -4,12 +4,12 @@
 package resourcesmisc_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	ctlresm "github.com/k14s/kapp/pkg/kapp/resourcesmisc"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppsV1DeploymentMinRepAvailable(t *testing.T) {

--- a/pkg/kapp/resourcesmisc/apps_v1_deployment_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_deployment_test.go
@@ -4,6 +4,7 @@
 package resourcesmisc_test
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
@@ -45,23 +46,22 @@ status:
 		Successful: false,
 		Message:    "Waiting for at least 1 available replicas (currently 4 available)",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	configYAML = strings.Replace(configYAML, "availableReplicas: 4", "availableReplicas: 5", -1)
 
 	state = buildDep(configYAML, t).IsDoneApplying()
-	if state != (ctlresm.DoneApplyState{Done: true, Successful: true, Message: ""}) {
-		t.Fatalf("Found incorrect state: %#v", state)
+	expectedState = ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: true,
+		Message:    "",
 	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 }
 
 func buildDep(resourcesBs string, t *testing.T) *ctlresm.AppsV1Deployment {
 	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
-	if err != nil {
-		t.Fatalf("Expected resources to parse")
-	}
+	require.NoErrorf(t, err, "Expected resources to parse")
 
 	return ctlresm.NewAppsV1Deployment(newResources[0], newResources[1:])
 }

--- a/pkg/kapp/resourcesmisc/apps_v1_stateful_set_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_stateful_set_test.go
@@ -4,6 +4,7 @@
 package resourcesmisc_test
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
@@ -28,9 +29,7 @@ spec:
 		Successful: false,
 		Message:    "Waiting for generation 1 to be observed",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	currentData = `
 apiVersion: apps/v1
@@ -54,9 +53,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 2 replicas to be updated",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	currentData = strings.Replace(currentData, "currentReplicas: 1", "currentReplicas: 3", -1)
 	currentData = strings.Replace(currentData, "updatedReplicas: 1", "updatedReplicas: 3", -1)
@@ -69,9 +66,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 1 replicas to be ready",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	currentData = strings.Replace(currentData, "readyReplicas: 2", "readyReplicas: 3", -1)
 
@@ -81,9 +76,8 @@ status:
 		Successful: true,
 		Message:    "",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
+
 }
 
 func TestAppsV1StatefulSetUpdate(t *testing.T) {
@@ -109,9 +103,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for generation 2 to be observed",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet controller marks one of the "current" pods for deletion. (but all 3 are still ready, at this moment)
 	currentData = strings.Replace(currentData, "updatedReplicas: 3", "updatedReplicas: 0", -1) // new image ==> new updateRevision ==> now, there are no pods of that revision
@@ -124,9 +116,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 3 replicas to be updated",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet Controller deleted one pod, and replaced it with one updated pod.
 	currentData = strings.Replace(currentData, "readyReplicas: 3", "readyReplicas: 2", -1)
@@ -138,9 +128,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 2 replicas to be updated",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet Controller updated all pods, and all but the last pod are ready.
 	currentData = strings.Replace(currentData, "updatedReplicas: 1", "updatedReplicas: 3", -1)
@@ -152,9 +140,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 1 replicas to be ready",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	currentData = strings.Replace(currentData, "readyReplicas: 2", "readyReplicas: 3", -1)
 
@@ -164,9 +150,8 @@ status:
 		Successful: true,
 		Message:    "",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
+
 }
 
 func TestAppsV1StatefulSetUpdatePartition(t *testing.T) {
@@ -195,9 +180,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for generation 2 to be observed",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet controller marks one of the "current" pods for deletion. (but all 3 are still ready, at this moment)
 	currentData = strings.Replace(currentData, "updatedReplicas: 3", "updatedReplicas: 0", -1) // new image ==> new updateRevision ==> now, there are no pods of that revision
@@ -210,9 +193,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 2 replicas to be updated (updating only 2 of 3 total)",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet Controller deleted one pod, and replaced it with one updated pod.
 	currentData = strings.Replace(currentData, "readyReplicas: 3", "readyReplicas: 2", -1)
@@ -224,9 +205,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 1 replicas to be updated (updating only 2 of 3 total)",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet Controller updated all pods, and all but the last pod are ready.
 	currentData = strings.Replace(currentData, "updatedReplicas: 1", "updatedReplicas: 2", -1)
@@ -238,9 +217,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 1 replicas to be ready",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	currentData = strings.Replace(currentData, "readyReplicas: 2", "readyReplicas: 3", -1)
 
@@ -250,9 +227,8 @@ status:
 		Successful: true,
 		Message:    "",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
+
 }
 
 func TestAppsV1StatefulSetScaleDown(t *testing.T) {
@@ -278,9 +254,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for generation 2 to be observed",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet controller marks one of the "current" pods for deletion. Updated == current since scaling change does not create a new revision.
 	currentData = strings.Replace(currentData, "updatedReplicas: 2", "updatedReplicas: 1", -1)
@@ -293,9 +267,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 1 replicas to be deleted",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	currentData = strings.Replace(currentData, "readyReplicas: 2", "readyReplicas: 1", -1)
 
@@ -305,9 +277,7 @@ status:
 		Successful: false,
 		Message:    "Waiting for 1 replicas to be deleted",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 
 	// StatefulSet Controller has finished removing replicas
 	currentData = strings.Replace(currentData, "status:\n  replicas: 2", "status:\n  replicas: 1", -1)
@@ -318,16 +288,12 @@ status:
 		Successful: true,
 		Message:    "",
 	}
-	if state != expectedState {
-		t.Fatalf("Found incorrect state: %#v", state)
-	}
+	require.Equal(t, expectedState, state, "Found incorrect state")
 }
 
 func buildStatefulSet(resourcesBs string, t *testing.T) *ctlresm.AppsV1StatefulSet {
 	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
-	if err != nil {
-		t.Fatalf("Expected resources to parse")
-	}
+	require.NoErrorf(t, err, "Expected resources to parse")
 
 	return ctlresm.NewAppsV1StatefulSet(newResources[0], nil)
 }

--- a/pkg/kapp/resourcesmisc/apps_v1_stateful_set_test.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_stateful_set_test.go
@@ -4,12 +4,12 @@
 package resourcesmisc_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	ctlresm "github.com/k14s/kapp/pkg/kapp/resourcesmisc"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppsV1StatefulSetCreation(t *testing.T) {


### PR DESCRIPTION
Update tests in **pkg/kapp/resourcemisc** to use testify/require instead of value comparisons and Fatal.
Fixes https://github.com/vmware-tanzu/carvel-kapp/issues/349