### PR TITLE
349 | Update tests to use testify/require

### DIFF
--- a/test/e2e/annotations_test.go
+++ b/test/e2e/annotations_test.go
@@ -467,8 +467,9 @@ data:
 		require.NoErrorf(t, err, "Expected to successfully unmarshal")
 
 		_, versionedAnnExists := respKubectl.Annotations["kapp.k14s.io/versioned"]
-		isConditionsMet := respKubectl.Kind == "ConfigMap" || respKubectl.Name == "config" || versionedAnnExists
-		require.True(t, isConditionsMet, "Expected to have versioned ConfigMap resource")
+		require.Condition(t, func() bool {
+			return respKubectl.Kind == "ConfigMap" && respKubectl.Name == "config" && versionedAnnExists
+		}, "Expected to have versioned ConfigMap resource")
 
 		kappOut, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml)})

--- a/test/e2e/annotations_test.go
+++ b/test/e2e/annotations_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -463,14 +464,11 @@ data:
 		respKubectl := corev1.ConfigMap{}
 
 		err := json.Unmarshal([]byte(out), &respKubectl)
-		if err != nil {
-			t.Fatalf("Expected to successfully unmarshal: %s", err)
-		}
+		require.NoErrorf(t, err, "Expected to successfully unmarshal")
 
 		_, versionedAnnExists := respKubectl.Annotations["kapp.k14s.io/versioned"]
-		if respKubectl.Kind != "ConfigMap" || respKubectl.Name != "config" || !versionedAnnExists {
-			t.Fatalf("Expected to have versioned ConfigMap resource")
-		}
+		isConditionsMet := respKubectl.Kind == "ConfigMap" || respKubectl.Name == "config" || versionedAnnExists
+		require.True(t, isConditionsMet, "Expected to have versioned ConfigMap resource")
 
 		kappOut, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml)})

--- a/test/e2e/cluster_resource.go
+++ b/test/e2e/cluster_resource.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -41,9 +42,9 @@ func NewPresentClusterResource(kind, name, ns string, kubectl Kubectl) ClusterRe
 
 func NewMissingClusterResource(t *testing.T, kind, name, ns string, kubectl Kubectl) {
 	_, err := kubectl.RunWithOpts([]string{"get", kind, name, "-n", ns, "-o", "yaml"}, RunOpts{AllowError: true})
-	if err == nil || !strings.Contains(err.Error(), "Error from server (NotFound)") {
-		t.Fatalf("Expected resource to not exist")
-	}
+	isConditionsMet := err != nil || strings.Contains(err.Error(), "Error from server (NotFound)")
+
+	require.True(t, isConditionsMet, "Expected resource to not exist")
 }
 
 func (r ClusterResource) UID() string {

--- a/test/e2e/cluster_resource.go
+++ b/test/e2e/cluster_resource.go
@@ -42,9 +42,9 @@ func NewPresentClusterResource(kind, name, ns string, kubectl Kubectl) ClusterRe
 
 func NewMissingClusterResource(t *testing.T, kind, name, ns string, kubectl Kubectl) {
 	_, err := kubectl.RunWithOpts([]string{"get", kind, name, "-n", ns, "-o", "yaml"}, RunOpts{AllowError: true})
-	isConditionsMet := err != nil || strings.Contains(err.Error(), "Error from server (NotFound)")
-
-	require.True(t, isConditionsMet, "Expected resource to not exist")
+	require.Condition(t, func() bool {
+		return err != nil && strings.Contains(err.Error(), "Error from server (NotFound)")
+	}, "Expected resource to not exist")
 }
 
 func (r ClusterResource) UID() string {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -19,8 +19,8 @@ func validateChanges(t *testing.T, respTable []ui.JSONUITableResp, expected []ma
 		delete(row, "age")
 	}
 
-	require.Exactlyf(t, expected, respTable[0].Rows, "Expected to see correct changes, but did not")
-	require.Equalf(t, notesOp, respTable[0].Notes[0], "Expected to see correct summary, but did not")
-	require.Equalf(t, notesWaitTo, respTable[0].Notes[1], "Expected to see correct summary, but did not")
+	require.Exactlyf(t, expected, respTable[0].Rows, "Expected to see correct changes, but did not: '%s'", output)
+	require.Equalf(t, notesOp, respTable[0].Notes[0], "Expected to see correct summary, but did not: '%s'", output)
+	require.Equalf(t, notesWaitTo, respTable[0].Notes[1], "Expected to see correct summary, but did not: '%s'", output)
 
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -4,10 +4,10 @@
 package e2e
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/stretchr/testify/require"
 )
 
 // validateChanges: common func used by multiple test cases for validation between actual and expected
@@ -19,13 +19,8 @@ func validateChanges(t *testing.T, respTable []ui.JSONUITableResp, expected []ma
 		delete(row, "age")
 	}
 
-	if !reflect.DeepEqual(respTable[0].Rows, expected) {
-		t.Fatalf("Expected to see correct changes, but did not: '%s'", output)
-	}
-	if respTable[0].Notes[0] != notesOp {
-		t.Fatalf("Expected to see correct summary, but did not: '%s'", output)
-	}
-	if respTable[0].Notes[1] != notesWaitTo {
-		t.Fatalf("Expected to see correct summary, but did not: '%s'", output)
-	}
+	require.Exactlyf(t, expected, respTable[0].Rows, "Expected to see correct changes, but did not")
+	require.Equalf(t, notesOp, respTable[0].Notes[0], "Expected to see correct summary, but did not")
+	require.Equalf(t, notesWaitTo, respTable[0].Notes[1], "Expected to see correct summary, but did not")
+
 }

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -122,7 +122,6 @@ data:
 
 		secondData := NewPresentClusterResource("configmap", "second", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"data"}))
 		require.Exactlyf(t, map[string]interface{}{"keep": "", "keep2": "", "delete": ""}, secondData, "Expected value to be correct")
-
 	})
 }
 
@@ -191,7 +190,6 @@ secrets:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-
 		require.Len(t, secrets, 2, "Expected one set and one generated secret")
 		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0: %#v", secrets[0])
 
@@ -199,7 +197,6 @@ secrets:
 		require.True(t, strings.HasPrefix(generatedSecretName, "test-sa-with-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
 
 		secrets = NewPresentClusterResource("serviceaccount", "test-sa-without-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-
 		require.Len(t, secrets, 1, "Expected one set and one generated secret")
 		require.True(t, strings.HasPrefix(secrets[0].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-"), "Expected generated secret at idx0: %#v", secrets[0])
 	})
@@ -226,12 +223,10 @@ secrets:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-
 		require.Len(t, secrets, 3, "Expected one set and one generated secret")
 		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0")
 		require.Exactlyf(t, map[string]interface{}{"name": "new-some-secret"}, secrets[1], "Expected provided secret at idx1")
 		require.Exactlyf(t, map[string]interface{}{"name": generatedSecretName}, secrets[2], "Expected previous generated secret at idx2")
-
 	})
 
 	ensureDeploysWithNoChanges(yaml2)
@@ -241,16 +236,13 @@ secrets:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml3)})
 
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-
 		require.Len(t, secrets, 1, "Expected one set and one generated secret")
 		require.Exactlyf(t, map[string]interface{}{"name": generatedSecretName}, secrets[0], "Expected previous generated secret at idx0")
 
 		secrets = NewPresentClusterResource("serviceaccount", "test-sa-without-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-
 		require.Len(t, secrets, 2, "Expected one set and one generated secret")
 		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0")
 		require.True(t, strings.HasPrefix(secrets[1].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
-
 	})
 
 	ensureDeploysWithNoChanges(yaml3)

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -193,7 +193,7 @@ secrets:
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
 
 		require.Len(t, secrets, 2, "Expected one set and one generated secret")
-		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret")
+		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0: %#v", secrets[0])
 
 		generatedSecretName = secrets[1].(map[string]interface{})["name"].(string)
 		require.True(t, strings.HasPrefix(generatedSecretName, "test-sa-with-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
@@ -247,9 +247,9 @@ secrets:
 
 		secrets = NewPresentClusterResource("serviceaccount", "test-sa-without-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
 
-		require.True(t, strings.HasPrefix(secrets[1].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
 		require.Len(t, secrets, 2, "Expected one set and one generated secret")
 		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0")
+		require.True(t, strings.HasPrefix(secrets[1].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
 
 	})
 

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -108,14 +107,10 @@ data:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 
 		firstData := NewPresentClusterResource("configmap", "first", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"data"}))
-		if !reflect.DeepEqual(firstData, map[string]interface{}{"keep": "", "delete": ""}) {
-			t.Fatalf("Expected value to be correct: %#v", firstData)
-		}
+		require.Exactlyf(t, map[string]interface{}{"keep": "", "delete": ""}, firstData, "Expected value to be correct")
 
 		secondData := NewPresentClusterResource("configmap", "second", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"data"}))
-		if !reflect.DeepEqual(secondData, map[string]interface{}{"keep": "", "delete": ""}) {
-			t.Fatalf("Expected value to be correct: %#v", secondData)
-		}
+		require.Exactlyf(t, map[string]interface{}{"keep": "", "delete": ""}, secondData, "Expected value to be correct")
 	})
 
 	logger.Section("check rebases", func() {
@@ -123,14 +118,11 @@ data:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 
 		firstData := NewPresentClusterResource("configmap", "first", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"data"}))
-		if !reflect.DeepEqual(firstData, map[string]interface{}{"keep": "", "keep2": ""}) {
-			t.Fatalf("Expected value to be correct: %#v", firstData)
-		}
+		require.Exactlyf(t, map[string]interface{}{"keep": "", "keep2": ""}, firstData, "Expected value to be correct")
 
 		secondData := NewPresentClusterResource("configmap", "second", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"data"}))
-		if !reflect.DeepEqual(secondData, map[string]interface{}{"keep": "", "keep2": "", "delete": ""}) {
-			t.Fatalf("Expected value to be correct: %#v", secondData)
-		}
+		require.Exactlyf(t, map[string]interface{}{"keep": "", "keep2": "", "delete": ""}, secondData, "Expected value to be correct")
+
 	})
 }
 
@@ -199,24 +191,17 @@ secrets:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-		if len(secrets) != 2 {
-			t.Fatalf("Expected one set and one generated secret")
-		}
-		if !reflect.DeepEqual(secrets[0], map[string]interface{}{"name": "some-secret"}) {
-			t.Fatalf("Expected provided secret at idx0: %#v", secrets[0])
-		}
+
+		require.Len(t, secrets, 2, "Expected one set and one generated secret")
+		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret")
+
 		generatedSecretName = secrets[1].(map[string]interface{})["name"].(string)
-		if !strings.HasPrefix(generatedSecretName, "test-sa-with-secrets-token-") {
-			t.Fatalf("Expected generated secret at idx1: %#v", secrets[1])
-		}
+		require.True(t, strings.HasPrefix(generatedSecretName, "test-sa-with-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
 
 		secrets = NewPresentClusterResource("serviceaccount", "test-sa-without-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-		if len(secrets) != 1 {
-			t.Fatalf("Expected one set and one generated secret")
-		}
-		if !strings.HasPrefix(secrets[0].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-") {
-			t.Fatalf("Expected generated secret at idx0: %#v", secrets[0])
-		}
+
+		require.Len(t, secrets, 1, "Expected one set and one generated secret")
+		require.True(t, strings.HasPrefix(secrets[0].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-"), "Expected generated secret at idx0: %#v", secrets[0])
 	})
 
 	ensureDeploysWithNoChanges := func(yamlContent string) {
@@ -228,12 +213,8 @@ secrets:
 				resp := uitest.JSONUIFromBytes(t, []byte(out))
 				expected := []map[string]string{}
 
-				if !reflect.DeepEqual(resp.Tables[0].Rows, expected) {
-					t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-				}
-				if resp.Tables[0].Notes[0] != "Op:      0 create, 0 delete, 0 update, 0 noop" {
-					t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-				}
+				require.Exactlyf(t, expected, resp.Tables[0].Rows, "Expected to see correct changes, but did not")
+				require.Equalf(t, "Op:      0 create, 0 delete, 0 update, 0 noop", resp.Tables[0].Notes[0], "Expected to see correct summary, but did not")
 			})
 		}
 	}
@@ -245,18 +226,12 @@ secrets:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-		if len(secrets) != 3 {
-			t.Fatalf("Expected one set and one generated secret")
-		}
-		if !reflect.DeepEqual(secrets[0], map[string]interface{}{"name": "some-secret"}) {
-			t.Fatalf("Expected provided secret at idx0: %#v", secrets[0])
-		}
-		if !reflect.DeepEqual(secrets[1], map[string]interface{}{"name": "new-some-secret"}) {
-			t.Fatalf("Expected provided secret at idx1: %#v", secrets[0])
-		}
-		if !reflect.DeepEqual(secrets[2], map[string]interface{}{"name": generatedSecretName}) {
-			t.Fatalf("Expected previous generated secret at idx2: %#v", secrets[1])
-		}
+
+		require.Len(t, secrets, 3, "Expected one set and one generated secret")
+		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0")
+		require.Exactlyf(t, map[string]interface{}{"name": "new-some-secret"}, secrets[1], "Expected provided secret at idx1")
+		require.Exactlyf(t, map[string]interface{}{"name": generatedSecretName}, secrets[2], "Expected previous generated secret at idx2")
+
 	})
 
 	ensureDeploysWithNoChanges(yaml2)
@@ -266,23 +241,16 @@ secrets:
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml3)})
 
 		secrets := NewPresentClusterResource("serviceaccount", "test-sa-with-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-		if len(secrets) != 1 {
-			t.Fatalf("Expected one set and one generated secret")
-		}
-		if !reflect.DeepEqual(secrets[0], map[string]interface{}{"name": generatedSecretName}) {
-			t.Fatalf("Expected previous generated secret at idx0: %#v", secrets[0])
-		}
+
+		require.Len(t, secrets, 1, "Expected one set and one generated secret")
+		require.Exactlyf(t, map[string]interface{}{"name": generatedSecretName}, secrets[0], "Expected previous generated secret at idx0")
 
 		secrets = NewPresentClusterResource("serviceaccount", "test-sa-without-secrets", env.Namespace, kubectl).RawPath(ctlres.NewPathFromStrings([]string{"secrets"})).([]interface{})
-		if len(secrets) != 2 {
-			t.Fatalf("Expected one set and one generated secret")
-		}
-		if !reflect.DeepEqual(secrets[0], map[string]interface{}{"name": "some-secret"}) {
-			t.Fatalf("Expected provided secret at idx0: %#v", secrets[0])
-		}
-		if !strings.HasPrefix(secrets[1].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-") {
-			t.Fatalf("Expected generated secret at idx1: %#v", secrets[1])
-		}
+
+		require.True(t, strings.HasPrefix(secrets[1].(map[string]interface{})["name"].(string), "test-sa-without-secrets-token-"), "Expected generated secret at idx1: %#v", secrets[1])
+		require.Len(t, secrets, 2, "Expected one set and one generated secret")
+		require.Exactlyf(t, map[string]interface{}{"name": "some-secret"}, secrets[0], "Expected provided secret at idx0")
+
 	})
 
 	ensureDeploysWithNoChanges(yaml3)
@@ -438,12 +406,8 @@ data:
 		resp := uitest.JSONUIFromBytes(t, []byte(out))
 		expected := []map[string]string{}
 
-		if !reflect.DeepEqual(resp.Tables[0].Rows, expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[0] != "Op:      0 create, 0 delete, 0 update, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, resp.Tables[0].Rows, "Expected to see correct changes, but did not")
+		require.Equalf(t, "Op:      0 create, 0 delete, 0 update, 0 noop", resp.Tables[0].Notes[0], "Expected to see correct summary, but did not")
 
 		cm = NewPresentClusterResource("configmap", "test-cm", env.Namespace, kubectl)
 		data := cm.RawPath(ctlres.NewPathFromStrings([]string{"data"})).(map[string]interface{})

--- a/test/e2e/create_fallback_on_update_test.go
+++ b/test/e2e/create_fallback_on_update_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateFallbackOnUpdate(t *testing.T) {
@@ -68,9 +69,7 @@ imagePullSecrets:
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{AllowError: true, StdinReader: strings.NewReader(yamlNoCreateStrategy)})
 
-		if !strings.Contains(err.Error(), `serviceaccounts "default" already exists`) {
-			t.Fatalf("Expected serviceaccount to be already created, but error was: %s", err)
-		}
+		require.Containsf(t, err.Error(), `serviceaccounts "default" already exists`, "Expected serviceaccount to be already created, but error was: %s", err)
 
 		cleanUp()
 	})
@@ -86,8 +85,6 @@ imagePullSecrets:
 
 		resp := uitest.JSONUIFromBytes(t, []byte(out))
 
-		if len(resp.Tables[0].Rows) != 0 {
-			t.Fatalf("Expected to see no changes, but did not: '%s'", out)
-		}
+		require.Len(t, resp.Tables[0].Rows, 0, "Expected to see no changes, but did not")
 	})
 }

--- a/test/e2e/create_update_delete_test.go
+++ b/test/e2e/create_update_delete_test.go
@@ -4,11 +4,11 @@
 package e2e
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateUpdateDelete(t *testing.T) {
@@ -78,9 +78,8 @@ data:
 
 		config := NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
 		val := config.RawPath(ctlres.NewPathFromStrings([]string{"data", "key"}))
-		if !reflect.DeepEqual(val, "value2") {
-			t.Fatalf("Expected value to be updated")
-		}
+
+		require.Exactlyf(t, "value2", val, "Expected value to be updated")
 
 		NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
 	})

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -240,6 +240,7 @@ func TestDiffExitStatus(t *testing.T) {
 		RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader("---\n")})
 
 	require.Errorf(t, err, "Expected to receive error")
+
 	require.Containsf(t, err.Error(), "Exiting after diffing with no pending changes (exit status 2)", "Expected to find stderr output")
 	require.Containsf(t, err.Error(), "exit code: '2'", "Expected to find exit code")
 
@@ -255,6 +256,7 @@ metadata:
 		RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(yaml1)})
 
 	require.Errorf(t, err, "Expected to receive error")
+
 	require.Containsf(t, err.Error(), "Exiting after diffing with pending changes (exit status 3)", "Expected to find stderr output")
 	require.Containsf(t, err.Error(), "exit code: '3'", "Expected to find exit code")
 }

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -4,12 +4,12 @@
 package e2e
 
 import (
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiff(t *testing.T) {
@@ -114,15 +114,9 @@ data:
 			"reconcile_state": "",
 		}}
 
-		if !reflect.DeepEqual(resp.Tables[0].Rows, expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[0] != "Op:      3 create, 0 delete, 0 update, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[1] != "Wait to: 3 reconcile, 0 delete, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, resp.Tables[0].Rows, "Expected to see correct changes, but did not")
+		require.Equalf(t, "Op:      3 create, 0 delete, 0 update, 0 noop", resp.Tables[0].Notes[0], "Expected to see correct summary, but did not")
+		require.Equalf(t, "Wait to: 3 reconcile, 0 delete, 0 noop", resp.Tables[0].Notes[1], "Expected to see correct summary, but did not")
 	})
 
 	logger.Section("deploy no change", func() {
@@ -132,15 +126,9 @@ data:
 		resp := uitest.JSONUIFromBytes(t, []byte(out))
 		expected := []map[string]string{}
 
-		if !reflect.DeepEqual(resp.Tables[0].Rows, expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[0] != "Op:      0 create, 0 delete, 0 update, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[1] != "Wait to: 0 reconcile, 0 delete, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, resp.Tables[0].Rows, "Expected to see correct changes, but did not")
+		require.Equalf(t, "Op:      0 create, 0 delete, 0 update, 0 noop", resp.Tables[0].Notes[0], "Expected to see correct summary, but did not")
+		require.Equalf(t, "Wait to: 0 reconcile, 0 delete, 0 noop", resp.Tables[0].Notes[1], "Expected to see correct summary, but did not")
 	})
 
 	logger.Section("deploy update with 1 delete, 1 update, 1 create", func() {
@@ -184,15 +172,9 @@ data:
 			"reconcile_state": "",
 		}}
 
-		if !reflect.DeepEqual(replaceAge(resp.Tables[0].Rows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[0] != "Op:      1 create, 1 delete, 1 update, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[1] != "Wait to: 2 reconcile, 1 delete, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(resp.Tables[0].Rows), "Expected to see correct changes, but did not")
+		require.Equalf(t, "Op:      1 create, 1 delete, 1 update, 0 noop", resp.Tables[0].Notes[0], "Expected to see correct summary, but did not")
+		require.Equalf(t, "Wait to: 2 reconcile, 1 delete, 0 noop", resp.Tables[0].Notes[1], "Expected to see correct summary, but did not")
 	})
 
 	logger.Section("delete", func() {
@@ -235,15 +217,9 @@ data:
 			"reconcile_state": "ok",
 		}}
 
-		if !reflect.DeepEqual(replaceAge(resp.Tables[0].Rows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[0] != "Op:      0 create, 3 delete, 0 update, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
-		if resp.Tables[0].Notes[1] != "Wait to: 0 reconcile, 3 delete, 0 noop" {
-			t.Fatalf("Expected to see correct summary, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(resp.Tables[0].Rows), "Expected to see correct changes, but did not")
+		require.Equalf(t, "Op:      0 create, 3 delete, 0 update, 0 noop", resp.Tables[0].Notes[0], "Expected to see correct summary, but did not")
+		require.Equalf(t, "Wait to: 0 reconcile, 3 delete, 0 noop", resp.Tables[0].Notes[1], "Expected to see correct summary, but did not")
 	})
 }
 
@@ -262,16 +238,10 @@ func TestDiffExitStatus(t *testing.T) {
 	_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name,
 		"--diff-run", "--diff-exit-status", "--dangerous-allow-empty-list-of-resources"},
 		RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader("---\n")})
-	if err == nil {
-		t.Fatalf("Expected to receive error")
-	}
 
-	if !strings.Contains(err.Error(), "Exiting after diffing with no pending changes (exit status 2)") {
-		t.Fatalf("Expected to find stderr output")
-	}
-	if !strings.Contains(err.Error(), "exit code: '2'") {
-		t.Fatalf("Expected to find exit code")
-	}
+	require.Errorf(t, err, "Expected to receive error")
+	require.Containsf(t, err.Error(), "Exiting after diffing with no pending changes (exit status 2)", "Expected to find stderr output")
+	require.Containsf(t, err.Error(), "exit code: '2'", "Expected to find exit code")
 
 	yaml1 := `
 apiVersion: v1
@@ -283,16 +253,10 @@ metadata:
 	_, err = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name,
 		"--diff-run", "--diff-exit-status"},
 		RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(yaml1)})
-	if err == nil {
-		t.Fatalf("Expected to receive error")
-	}
 
-	if !strings.Contains(err.Error(), "Exiting after diffing with pending changes (exit status 3)") {
-		t.Fatalf("Expected to find stderr output")
-	}
-	if !strings.Contains(err.Error(), "exit code: '3'") {
-		t.Fatalf("Expected to find exit code")
-	}
+	require.Errorf(t, err, "Expected to receive error")
+	require.Containsf(t, err.Error(), "Exiting after diffing with pending changes (exit status 3)", "Expected to find stderr output")
+	require.Containsf(t, err.Error(), "exit code: '3'", "Expected to find exit code")
 }
 
 func TestDiffMaskRules(t *testing.T) {
@@ -402,9 +366,7 @@ data:
 
 	out = replaceAnnsLabels(out)
 
-	if !strings.Contains(out, expectedOutput) {
-		t.Fatalf("Did not find expected diff output >>%s<< in >>%s<<", out, expectedOutput)
-	}
+	require.Containsf(t, out, expectedOutput, "Did not find expected diff output")
 
 	out, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-c", "-p"},
 		RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
@@ -419,9 +381,7 @@ data:
   5,  5   metadata:
 `
 
-	if !strings.Contains(out, expectedOutput) {
-		t.Fatalf("Did not find expected diff output >>%s<< in >>%s<<", out, expectedOutput)
-	}
+	require.Containsf(t, out, expectedOutput, "Did not find expected diff output")
 }
 
 func replaceAge(result []map[string]string) []map[string]string {

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -4,10 +4,11 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type Env struct {

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
@@ -35,7 +36,5 @@ func (e Env) Validate(t *testing.T) {
 		errStrs = append(errStrs, "Expected Namespace to be non-empty")
 	}
 
-	if len(errStrs) > 0 {
-		t.Fatalf("%s", strings.Join(errStrs, "\n"))
-	}
+	require.Len(t, errStrs, 0, "%s", strings.Join(errStrs, "\n"))
 }

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -37,5 +37,5 @@ func (e Env) Validate(t *testing.T) {
 		errStrs = append(errStrs, "Expected Namespace to be non-empty")
 	}
 
-	require.Len(t, errStrs, 0, "%s", strings.Join(errStrs, "\n"))
+	require.Lenf(t, errStrs, 0, "%s", strings.Join(errStrs, "\n"))
 }

--- a/test/e2e/filter_test.go
+++ b/test/e2e/filter_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 )
@@ -66,9 +67,7 @@ kapp-test  redis-config   ConfigMap  -       -    create  -       reconcile  -  
 Op:      2 create, 0 delete, 0 update, 0 noop
 Wait to: 2 reconcile, 0 delete, 0 noop
 `
-		if !strings.Contains(out, expectedOutput1) {
-			t.Fatalf("Did not find expected diff output >>%s<< in >>%s<<", out, expectedOutput1)
-		}
+		require.Contains(t, out, expectedOutput1, "Did not find expected diff output")
 	})
 
 	logger.Section("not equal filter label", func() {
@@ -83,9 +82,7 @@ kapp-test  redis-config   ConfigMap  -       -    create  -       reconcile  -  
 Op:      2 create, 0 delete, 0 update, 0 noop
 Wait to: 2 reconcile, 0 delete, 0 noop
 `
-		if !strings.Contains(out, expectedOutput2) {
-			t.Fatalf("Did not find expected diff output >>%s<< in >>%s<<", out, expectedOutput2)
-		}
+		require.Contains(t, out, expectedOutput2, "Did not find expected diff output")
 	})
 
 	logger.Section("test filter flag", func() {
@@ -99,9 +96,7 @@ kapp-test  redis-primary  Service  -       -    create  -       reconcile  -   -
 Op:      1 create, 0 delete, 0 update, 0 noop
 Wait to: 1 reconcile, 0 delete, 0 noop
 `
-		if !strings.Contains(out, expectedOutput3) {
-			t.Fatalf("Did not find expected diff output >>%s<< in >>%s<<", out, expectedOutput3)
-		}
+		require.Contains(t, out, expectedOutput3, "Did not find expected diff output")
 	})
 
 	logger.Section("test multiple filter flags together", func() {
@@ -117,8 +112,6 @@ kapp-test  redis-config2  ConfigMap  -       -    create  -       reconcile  -  
 Op:      1 create, 0 delete, 0 update, 0 noop
 Wait to: 1 reconcile, 0 delete, 0 noop
 `
-		if !strings.Contains(out, expectedOutput4) {
-			t.Fatalf("Did not find expected diff output >>%s<< in >>%s<<", out, expectedOutput4)
-		}
+		require.Contains(t, out, expectedOutput4, "Did not find expected diff output")
 	})
 }

--- a/test/e2e/filter_test.go
+++ b/test/e2e/filter_test.go
@@ -4,9 +4,10 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilter(t *testing.T) {

--- a/test/e2e/formatted_error_test.go
+++ b/test/e2e/formatted_error_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"github.com/stretchr/testify/require"
 	"regexp"
 	"strings"
 	"testing"
@@ -70,10 +71,8 @@ kapp: Error: Applying create job/successful-job (batch/v1) namespace: default:
 		replaceUIDs := regexp.MustCompile(`"controller-uid":"[^"]+"`)
 		out = replaceUIDs.ReplaceAllString(out, "-replaced-")
 
-		if !strings.Contains(out, expectedErr) {
-			t.Fatalf("Expected to see expected err in output, but did not: %d chars >>>%s<<< vs %d chars >>>%s<<<",
-				len(out), replaceSpace(out), len(expectedErr), replaceSpace(expectedErr))
-		}
+		require.Containsf(t, out, expectedErr, "Expected to see expected err in output, but did not: %d chars >>>%s<<< vs %d chars >>>%s<<<",
+			len(out), replaceSpace(out), len(expectedErr), replaceSpace(expectedErr))
 	})
 }
 

--- a/test/e2e/formatted_error_test.go
+++ b/test/e2e/formatted_error_test.go
@@ -4,10 +4,11 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormattedError(t *testing.T) {
@@ -71,11 +72,6 @@ kapp: Error: Applying create job/successful-job (batch/v1) namespace: default:
 		replaceUIDs := regexp.MustCompile(`"controller-uid":"[^"]+"`)
 		out = replaceUIDs.ReplaceAllString(out, "-replaced-")
 
-		require.Containsf(t, out, expectedErr, "Expected to see expected err in output, but did not: %d chars >>>%s<<< vs %d chars >>>%s<<<",
-			len(out), replaceSpace(out), len(expectedErr), replaceSpace(expectedErr))
+		require.Containsf(t, out, expectedErr, "Expected to see expected err in output, but did not")
 	})
-}
-
-func replaceSpace(in string) string {
-	return strings.ReplaceAll(in, " ", "#")
 }

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -4,7 +4,7 @@
 package e2e
 
 import (
-	"strings"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -13,10 +13,8 @@ func TestHelpCommandGroup(t *testing.T) {
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
 
 	_, err := kapp.RunWithOpts([]string{"app-group"}, RunOpts{NoNamespace: true, AllowError: true})
-	if err == nil {
-		t.Fatalf("Expected error")
-	}
-	if !strings.Contains(err.Error(), "Error: Use one of available subcommands: delete, deploy") {
-		t.Fatalf("Expected helpful error message, but was '%s'", err.Error())
-	}
+
+	require.Errorf(t, err, "Expected to receive error")
+	require.Contains(t, err.Error(), "Error: Use one of available subcommands: delete, deploy",
+		"Expected helpful error message")
 }

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -4,8 +4,9 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHelpCommandGroup(t *testing.T) {

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -13,8 +13,7 @@ func TestHelpCommandGroup(t *testing.T) {
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
 
 	_, err := kapp.RunWithOpts([]string{"app-group"}, RunOpts{NoNamespace: true, AllowError: true})
-
 	require.Errorf(t, err, "Expected to receive error")
-	require.Contains(t, err.Error(), "Error: Use one of available subcommands: delete, deploy",
-		"Expected helpful error message")
+
+	require.Contains(t, err.Error(), "Error: Use one of available subcommands: delete, deploy", "Expected helpful error message")
 }

--- a/test/e2e/ignore_failing_api_services_flag_test.go
+++ b/test/e2e/ignore_failing_api_services_flag_test.go
@@ -4,11 +4,11 @@
 package e2e
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIgnoreFailingAPIServices(t *testing.T) {
@@ -122,20 +122,16 @@ metadata:
 			"reconcile_state": "ok",
 		}}
 
-		if !reflect.DeepEqual(replaceAge(resp.Tables[0].Rows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(resp.Tables[0].Rows), "Expected to see correct changes")
 	})
 
 	logger.Section("deploy app that uses failing api service", func() {
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name3}, RunOpts{
 			AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml3)})
-		if err == nil {
-			t.Fatalf("Expected error when deploying with failing api service")
-		}
-		if !strings.Contains(err.Error(), "unable to retrieve the complete list of server APIs: dummykapptest.com/v1: the server is currently unable to handle the request") {
-			t.Fatalf("Expected api retrieval error but was '%s'", err)
-		}
+
+		require.Errorf(t, err, "Expected error when deploying with failing api service")
+		require.Contains(t, err.Error(), "unable to retrieve the complete list of server APIs: dummykapptest.com/v1: the server is currently unable to handle the request",
+			"Expected api retrieval error")
 	})
 
 	logger.Section("deploy app that uses failing api service and try to ignore it", func() {
@@ -143,12 +139,10 @@ metadata:
 
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name3, ignoreFlag}, RunOpts{
 			AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml3)})
-		if err == nil {
-			t.Fatalf("Expected error when deploying with failing api service")
-		}
-		if !strings.Contains(err.Error(), "Expected to find kind 'dummykapptest.com/v1/Foo', but did not") {
-			t.Fatalf("Expected CRD retrieval error but was '%s'", err)
-		}
+
+		require.Errorf(t, err, "Expected error when deploying with failing api service")
+		require.Contains(t, err.Error(), "Expected to find kind 'dummykapptest.com/v1/Foo', but did not",
+			"Expected CRD retrieval error")
 	})
 
 	logger.Section("delete app that does not use api service", func() {
@@ -279,20 +273,16 @@ spec: {}
 			"reconcile_state": "ok",
 		}}
 
-		if !reflect.DeepEqual(replaceAge(resp.Tables[0].Rows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(resp.Tables[0].Rows), "Expected to see correct changes")
 	})
 
 	logger.Section("deploy app that uses failing group version", func() {
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name3, "--apply-timeout=5s"}, RunOpts{
 			AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml3)})
-		if err == nil {
-			t.Fatalf("Expected error when deploying with failing group version")
-		}
-		if !strings.Contains(err.Error(), `service "failing-group-version-webhook" not found`) {
-			t.Fatalf("Expected api retrieval error but was '%s'", err)
-		}
+
+		require.Errorf(t, err, "Expected error when deploying with failing group version")
+		require.Contains(t, err.Error(), `service "failing-group-version-webhook" not found`,
+			"Expected api retrieval error")
 	})
 
 	logger.Section("delete app that uses failing group version", func() {

--- a/test/e2e/ignore_failing_api_services_flag_test.go
+++ b/test/e2e/ignore_failing_api_services_flag_test.go
@@ -128,8 +128,8 @@ metadata:
 	logger.Section("deploy app that uses failing api service", func() {
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name3}, RunOpts{
 			AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml3)})
-
 		require.Errorf(t, err, "Expected error when deploying with failing api service")
+
 		require.Contains(t, err.Error(), "unable to retrieve the complete list of server APIs: dummykapptest.com/v1: the server is currently unable to handle the request",
 			"Expected api retrieval error")
 	})
@@ -139,10 +139,9 @@ metadata:
 
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name3, ignoreFlag}, RunOpts{
 			AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml3)})
-
 		require.Errorf(t, err, "Expected error when deploying with failing api service")
-		require.Contains(t, err.Error(), "Expected to find kind 'dummykapptest.com/v1/Foo', but did not",
-			"Expected CRD retrieval error")
+
+		require.Contains(t, err.Error(), "Expected to find kind 'dummykapptest.com/v1/Foo', but did not", "Expected CRD retrieval error")
 	})
 
 	logger.Section("delete app that does not use api service", func() {
@@ -279,10 +278,9 @@ spec: {}
 	logger.Section("deploy app that uses failing group version", func() {
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name3, "--apply-timeout=5s"}, RunOpts{
 			AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml3)})
-
 		require.Errorf(t, err, "Expected error when deploying with failing group version")
-		require.Contains(t, err.Error(), `service "failing-group-version-webhook" not found`,
-			"Expected api retrieval error")
+
+		require.Contains(t, err.Error(), `service "failing-group-version-webhook" not found`, "Expected api retrieval error")
 	})
 
 	logger.Section("delete app that uses failing group version", func() {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -4,11 +4,11 @@
 package e2e
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInspect(t *testing.T) {
@@ -83,9 +83,7 @@ spec:
 			})
 		}
 
-		if !reflect.DeepEqual(replaceAge(respRows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(respRows), "Expected to see correct changes")
 	})
 
 	logger.Section("tree inspect", func() {
@@ -128,8 +126,6 @@ spec:
 			})
 		}
 
-		if !reflect.DeepEqual(replaceAge(respRows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(respRows), "Expected to see correct changes")
 	})
 }

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -6,12 +6,13 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type Kapp struct {

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"os/exec"
@@ -88,9 +89,7 @@ func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 		err = fmt.Errorf("Execution error: stdout: '%s' stderr: '%s' error: '%s' exit code: '%d'",
 			stdoutStr, stderr.String(), err, exitCode)
 
-		if !opts.AllowError {
-			k.t.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args, opts), err)
-		}
+		require.Truef(k.t, opts.AllowError, "Failed to successfully execute '%s': %v", k.cmdDesc(args, opts), err)
 	}
 
 	return stdoutStr, err

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -6,11 +6,12 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type Kubectl struct {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"strings"
@@ -57,9 +58,7 @@ func (k Kubectl) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	if err != nil {
 		err = fmt.Errorf("Execution error: stderr: '%s' error: '%s'", stderr.String(), err)
 
-		if !opts.AllowError {
-			k.t.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args), err)
-		}
+		require.Truef(k.t, opts.AllowError, "Failed to successfully execute '%s': %v", k.cmdDesc(args), err)
 	}
 
 	return stdout.String(), err

--- a/test/e2e/order_test.go
+++ b/test/e2e/order_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"github.com/stretchr/testify/require"
 	"regexp"
 	"sort"
 	"strings"
@@ -122,10 +123,7 @@ Wait to: 7 reconcile, 0 delete, 0 noop
 Succeeded
 `))
 
-		if out != expectedOutput {
-			t.Fatalf("Expected output to equal (%d) >>>%s<<< but was (%d) >>>%s<<<",
-				len(expectedOutput), expectedOutput, len(out), out)
-		}
+		require.Equal(t, expectedOutput, out)
 	})
 
 	logger.Section("deploy with upsert before delete", func() {
@@ -207,10 +205,7 @@ Wait to: 1 reconcile, 1 delete, 0 noop
 Succeeded
 `))
 
-		if out != expectedOutput {
-			t.Fatalf("Expected output to equal (%d) >>>%s<<< but was (%d) >>>%s<<<",
-				len(expectedOutput), expectedOutput, len(out), out)
-		}
+		require.Equal(t, expectedOutput, out)
 	})
 }
 

--- a/test/e2e/order_test.go
+++ b/test/e2e/order_test.go
@@ -4,11 +4,12 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestOrder(t *testing.T) {

--- a/test/e2e/template_test.go
+++ b/test/e2e/template_test.go
@@ -4,12 +4,12 @@
 package e2e
 
 import (
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTemplate(t *testing.T) {
@@ -230,9 +230,8 @@ data:
 		NewPresentClusterResource("configmap", "config-ver-1", env.Namespace, kubectl)
 
 		val := dep.RawPath(ctlres.NewPathFromInterfaces(depPath))
-		if !reflect.DeepEqual(val, "config-ver-1") {
-			t.Fatalf("Expected value to be updated")
-		}
+
+		require.Exactlyf(t, "config-ver-1", val, "Expected value to be updated")
 	})
 
 	logger.Section("deploy update that changes configmap", func() {
@@ -245,9 +244,8 @@ data:
 		NewPresentClusterResource("configmap", "config-ver-2", env.Namespace, kubectl)
 
 		val := dep.RawPath(ctlres.NewPathFromInterfaces(depPath))
-		if !reflect.DeepEqual(val, "config-ver-2") {
-			t.Fatalf("Expected value to be updated")
-		}
+
+		require.Exactlyf(t, "config-ver-2", val, "Expected value to be updated")
 	})
 
 	logger.Section("deploy update that has no changes", func() {
@@ -260,9 +258,8 @@ data:
 		NewPresentClusterResource("configmap", "config-ver-2", env.Namespace, kubectl)
 
 		val := dep.RawPath(ctlres.NewPathFromInterfaces(depPath))
-		if !reflect.DeepEqual(val, "config-ver-2") {
-			t.Fatalf("Expected value to be updated")
-		}
+
+		require.Exactlyf(t, "config-ver-2", val, "Expected value to be updated")
 	})
 
 	// TODO deploy via patch or filter
@@ -284,8 +281,5 @@ func checkChangesOutput(t *testing.T, actualOutput, expectedOutput string) {
 	// printLines("actual", actualOutput)
 	// printLines("expected", expectedOutput)
 
-	if actualOutput != expectedOutput {
-		t.Fatalf("Expected output to match:  %d >>>%s<<< vs %d >>>%s<<<",
-			len(actualOutput), actualOutput, len(expectedOutput), expectedOutput)
-	}
+	require.Equalf(t, expectedOutput, actualOutput, "Expected output to match actual")
 }

--- a/test/e2e/transient_resource_test.go
+++ b/test/e2e/transient_resource_test.go
@@ -4,11 +4,11 @@
 package e2e
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransientResourceInspectDelete(t *testing.T) {
@@ -82,9 +82,7 @@ spec:
 			})
 		}
 
-		if !reflect.DeepEqual(replaceAge(respRows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(respRows), "Expected to see correct changes")
 	})
 
 	logger.Section("delete includes transient resource", func() {
@@ -132,9 +130,7 @@ spec:
 			})
 		}
 
-		if !reflect.DeepEqual(replaceAge(respRows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(respRows), "Expected to see correct changes")
 	})
 }
 
@@ -197,9 +193,8 @@ metadata:
 			"reconcile_info":  "",
 			"reconcile_state": "ok",
 		}}
-		if !reflect.DeepEqual(replaceAge(respRows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+
+		require.Exactlyf(t, expected, replaceAge(respRows), "Expected to see correct changes")
 	})
 
 	logger.Section("delete with previously transient resource (now non-transient)", func() {
@@ -247,9 +242,7 @@ metadata:
 			})
 		}
 
-		if !reflect.DeepEqual(replaceAge(respRows), expected) {
-			t.Fatalf("Expected to see correct changes, but did not: '%s'", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(respRows), "Expected to see correct changes")
 	})
 }
 

--- a/test/e2e/update_replace_test.go
+++ b/test/e2e/update_replace_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 )
@@ -67,9 +68,7 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 		curr := NewPresentClusterResource(objKind, objName, env.Namespace, kubectl)
 
-		if prev.UID() == curr.UID() {
-			t.Fatalf("Expected object to be replaced, but found same UID")
-		}
+		require.NotEqual(t, prev.UID(), curr.UID(), "Expected object to be replaced, but found same UID")
 	})
 
 	logger.Section("deploy update to service that does not set spec.clusterIP", func() {
@@ -78,9 +77,7 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 		curr := NewPresentClusterResource(objKind, objName, env.Namespace, kubectl)
 
-		if prev.UID() != curr.UID() {
-			t.Fatalf("Expected object to be rebased, but found different UID")
-		}
+		require.Equal(t, prev.UID(), curr.UID(), "Expected object to be rebased, but found different UID")
 	})
 }
 
@@ -143,9 +140,7 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 		curr := NewPresentClusterResource(objKind, objName, env.Namespace, kubectl)
 
-		if prev.UID() == curr.UID() {
-			t.Fatalf("Expected object to be replaced, but found same UID")
-		}
+		require.NotEqual(t, prev.UID(), curr.UID(), "Expected object to be replaced, but found same UID")
 	})
 
 	logger.Section("deploy update to service that does not set spec.clusterIP", func() {
@@ -154,8 +149,6 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 		curr := NewPresentClusterResource(objKind, objName, env.Namespace, kubectl)
 
-		if prev.UID() != curr.UID() {
-			t.Fatalf("Expected object to be rebased, but found different UID")
-		}
+		require.Equal(t, prev.UID(), curr.UID(), "Expected object to be rebased, but found different UID")
 	})
 }

--- a/test/e2e/update_replace_test.go
+++ b/test/e2e/update_replace_test.go
@@ -4,9 +4,10 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateFallbackOnReplace(t *testing.T) {

--- a/test/e2e/update_retry_on_conflict_test.go
+++ b/test/e2e/update_retry_on_conflict_test.go
@@ -183,7 +183,6 @@ spec:
 		_, err := kapp.RunWithOpts([]string{"deploy", "--tty", "-f", tmpFile.Name(), "-a", name},
 			RunOpts{IntoNs: true, StdinReader: promptOutput.YesReader(),
 				StdoutWriter: promptOutput.OutputWriter(), Interactive: true, AllowError: true})
-
 		require.Errorf(t, err, "Expected error, but err was nil")
 
 		require.Contains(t, err.Error(), "Failed to update due to resource conflict (approved diff no longer matches)",
@@ -312,7 +311,8 @@ func (p promptOutput) WaitPresented() {
 			break
 		}
 	}
-	require.NoError(p.t, scanner.Err())
+	err := scanner.Err()
+	require.NoError(p.t, err)
 }
 
 func newTmpFile(content string, t *testing.T) *os.File {

--- a/test/e2e/update_retry_on_conflict_test.go
+++ b/test/e2e/update_retry_on_conflict_test.go
@@ -5,12 +5,13 @@ package e2e
 
 import (
 	"bufio"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateRetryOnConflict_WithoutConflict(t *testing.T) {

--- a/test/e2e/update_retry_on_conflict_test.go
+++ b/test/e2e/update_retry_on_conflict_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"bufio"
+	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"os"
@@ -182,15 +183,14 @@ spec:
 		_, err := kapp.RunWithOpts([]string{"deploy", "--tty", "-f", tmpFile.Name(), "-a", name},
 			RunOpts{IntoNs: true, StdinReader: promptOutput.YesReader(),
 				StdoutWriter: promptOutput.OutputWriter(), Interactive: true, AllowError: true})
-		if err == nil {
-			t.Fatalf("Expected error, but err was nil")
-		}
-		if !strings.Contains(err.Error(), "Failed to update due to resource conflict (approved diff no longer matches)") {
-			t.Fatalf("Expected error to include resource conflict description, but was '%s'", err)
-		}
-		if !strings.Contains(err.Error(), "please apply your changes to the latest version and try again (reason: Conflict)") {
-			t.Fatalf("Expected error to include k8s reason, but was '%s'", err)
-		}
+
+		require.Errorf(t, err, "Expected error, but err was nil")
+
+		require.Contains(t, err.Error(), "Failed to update due to resource conflict (approved diff no longer matches)",
+			"Expected error to include resource conflict description")
+
+		require.Contains(t, err.Error(), "please apply your changes to the latest version and try again (reason: Conflict)",
+			"Expected error to include k8s reason")
 	})
 }
 
@@ -292,13 +292,11 @@ type promptOutput struct {
 
 func newPromptOutput(t *testing.T) promptOutput {
 	yesReader, yesWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	outputReader, outputWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	return promptOutput{t, yesWriter, yesReader, outputWriter, outputReader}
 }
 
@@ -314,21 +312,18 @@ func (p promptOutput) WaitPresented() {
 			break
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		p.t.Fatal(err)
-	}
+	require.NoError(p.t, scanner.Err())
 }
 
 func newTmpFile(content string, t *testing.T) *os.File {
 	file, err := ioutil.TempFile("", "kapp-test-update-retry-on-conflict")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := file.Write([]byte(content)); err != nil {
-		t.Fatal(err)
-	}
-	if err := file.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	_, err = file.Write([]byte(content))
+	require.NoError(t, err)
+
+	err = file.Close()
+	require.NoError(t, err)
+
 	return file
 }

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -4,7 +4,7 @@
 package e2e
 
 import (
-	"strings"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -14,7 +14,5 @@ func TestVersion(t *testing.T) {
 
 	out, _ := kapp.RunWithOpts([]string{"version"}, RunOpts{NoNamespace: true})
 
-	if !strings.Contains(out, "kapp version") {
-		t.Fatalf("Expected to find client version")
-	}
+	require.Contains(t, out, "kapp version", "Expected to find client version")
 }

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -4,8 +4,9 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersion(t *testing.T) {

--- a/test/e2e/versioned_explicit_reference_test.go
+++ b/test/e2e/versioned_explicit_reference_test.go
@@ -4,11 +4,11 @@
 package e2e
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionedExplicitReference(t *testing.T) {
@@ -176,9 +176,7 @@ data:
 			},
 		}
 
-		if !reflect.DeepEqual(resp.Tables[0].Rows, expected) {
-			t.Fatalf("Expected to see correct changes but recieved >>%s<<", out)
-		}
+		require.Exactlyf(t, expected, resp.Tables[0].Rows, "Expected to see correct changes")
 	})
 
 	logger.Section("update versioned resource", func() {
@@ -225,8 +223,6 @@ data:
 			},
 		}
 
-		if !reflect.DeepEqual(replaceAge(resp.Tables[0].Rows), expected) {
-			t.Fatalf("Expected to see correct changes but recieved >>%s<<", out)
-		}
+		require.Exactlyf(t, expected, replaceAge(resp.Tables[0].Rows), "Expected to see correct changes")
 	})
 }

--- a/test/e2e/wait_timeout_test.go
+++ b/test/e2e/wait_timeout_test.go
@@ -4,9 +4,10 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWaitTimeout(t *testing.T) {

--- a/test/e2e/wait_timeout_test.go
+++ b/test/e2e/wait_timeout_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 )
@@ -43,9 +44,7 @@ func TestWaitTimeout(t *testing.T) {
 			"100s", "--wait-resource-timeout", "1s", "--json"},
 			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(yaml1)})
 
-		if !strings.Contains(err.Error(), "Resource timed out waiting after 1s") {
-			t.Fatalf("Expected to see timed out, but did not: '%s'", err.Error())
-		}
+		require.Containsf(t, err.Error(), "Resource timed out waiting after 1s", "Expected to see timed out, but did not")
 	})
 
 	cleanUp()
@@ -55,9 +54,7 @@ func TestWaitTimeout(t *testing.T) {
 			"1s", "--wait-resource-timeout", "100s", "--json"},
 			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(yaml1)})
 
-		if !strings.Contains(err.Error(), "kapp: Error: Timed out waiting after 1s") {
-			t.Fatalf("Expected to see timed out, but did not: '%s'", err.Error())
-		}
+		require.Containsf(t, err.Error(), "kapp: Error: Timed out waiting after 1s", "Expected to see timed out, but did not")
 	})
 
 	cleanUp()
@@ -67,8 +64,6 @@ func TestWaitTimeout(t *testing.T) {
 			"10000s", "--wait-resource-timeout", "10000s", "--json"},
 			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(yaml1)})
 
-		if err != nil {
-			t.Fatalf("Expected to be successful without resource timeout: '%s'", err)
-		}
+		require.NoErrorf(t, err, "Expected to be successful without resource timeout")
 	})
 }

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -109,14 +109,15 @@ Succeeded`
 		expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
 
 		require.Equal(t, expectedOutput, out)
+	})
 
-		logger.Section("deploying with --warnings flag", func() {
-			yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
+	logger.Section("deploying with --warnings flag", func() {
+		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
 
-			out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName2, "--warnings=false"},
-				RunOpts{StdinReader: strings.NewReader(yaml)})
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName2, "--warnings=false"},
+			RunOpts{StdinReader: strings.NewReader(yaml)})
 
-			expectedOutput := `
+		expectedOutput := `
 Changes
 
 Namespace  Name  Kind     Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
@@ -134,11 +135,10 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 
 Succeeded`
 
-			out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
-			expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
+		out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
+		expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
 
-			require.Equal(t, expectedOutput, out)
-		})
+		require.Equal(t, expectedOutput, out)
 	})
 }
 

--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestWarningsFlag(t *testing.T) {
 	minorVersion, err := getServerMinorVersion()
-	if err != nil {
-		t.Fatalf("Error getting k8s server minor version, %v", err)
-	}
+	require.NoErrorf(t, err, "Error getting k8s server minor version")
+
 	if minorVersion < 19 {
 		t.Skip("Skipping test as warnings weren't introduced before v1.19")
 	}
@@ -108,18 +108,15 @@ Succeeded`
 		expectedOutput = strings.Replace(expectedOutput, "<custom-warning>", customWarning, 1)
 		expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
 
-		if expectedOutput != out {
-			t.Fatalf("Expected output with warning >>%s<<, but got >>%s<<\n", expectedOutput, out)
-		}
-	})
+		require.Equal(t, expectedOutput, out)
 
-	logger.Section("deploying with --warnings flag", func() {
-		yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
+		logger.Section("deploying with --warnings flag", func() {
+			yaml := strings.Replace(crYaml, "<cr-name>", "cr-2", 1)
 
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName2, "--warnings=false"},
-			RunOpts{StdinReader: strings.NewReader(yaml)})
+			out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", crName2, "--warnings=false"},
+				RunOpts{StdinReader: strings.NewReader(yaml)})
 
-		expectedOutput := `
+			expectedOutput := `
 Changes
 
 Namespace  Name  Kind     Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
@@ -137,11 +134,11 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 
 Succeeded`
 
-		out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
-		expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
-		if expectedOutput != out {
-			t.Fatalf("Expected output without warning >>%s<< but got >>%s<<\n", expectedOutput, out)
-		}
+			out = strings.TrimSpace(replaceTarget(replaceSpaces(replaceTs(out))))
+			expectedOutput = strings.TrimSpace(replaceSpaces(expectedOutput))
+
+			require.Equal(t, expectedOutput, out)
+		})
 	})
 }
 


### PR DESCRIPTION
Update tests in test/e2e to use testify/require instead of value comparisons and Fatal.
Fixes #349