### PR TITLE
Fix: Remove input flag to trivy-action

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -29,7 +29,6 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'fs'
-          input: '.'
           ignore-unfixed: true
           format: 'template'
           template: '@/contrib/sarif.tpl'


### PR DESCRIPTION
The current trivy workflow does not work as the `input` flag is specified with `.` results in an error. 

```
2021-11-11T00:07:45.203Z	FATAL	flag provided but not defined: -input
Incorrect Usage: flag provided but not defined: -input
```

The input  flag is not actually needed, and the trivy-action defaults to the current directory anyways.

https://github.com/vmware-tanzu/carvel-kapp/blob/develop/.github/workflows/trivy-scan.yml

Example failure runs:

https://github.com/vmware-tanzu/carvel-kapp/actions/workflows/trivy-scan.yml