### PR TITLE
Don't panic on error in rebaseRule provided by user

### DIFF
--- a/pkg/kapp/resources/mod_field_copy.go
+++ b/pkg/kapp/resources/mod_field_copy.go
@@ -74,7 +74,7 @@ func (t FieldCopyMod) apply(obj interface{}, path Path, fullPath Path, srcs map[
 
 		case part.ArrayIndex != nil:
 			if isLast {
-				panic("Expected last part of the path to be map key")
+				return false, fmt.Errorf("Expected last part of the path to be map key")
 			}
 
 			switch {


### PR DESCRIPTION
User can provide rebaseRule with `{allIndexes: true}` as last element , which is not supported and should generate error message.

Other panics in this file left as is, because when these are more like asserts, indicating bug in the code when triggered.