### PR TITLE
Pinning trivy cloning to branch v0.22.0

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -32,7 +32,7 @@ jobs:
           brew install aquasecurity/trivy/trivy
           
           # Create trivy binary file
-          git clone --depth 1 https://github.com/aquasecurity/trivy
+          git clone --depth 1 -b "v0.22.0" https://github.com/aquasecurity/trivy
         
       - name: Run trivy to generate reports
         run: |  


### PR DESCRIPTION
We can remove this and the git clone code once trivy release v0.23.0

- there was a breaking change introduced on the trivy develop branch that moved the sarif template into go code and introduced the --format sarif flag. Once they release that we can move to using it