### PR TITLE
kapp deploy without disable original annotation when resource size exceed

### DIFF
--- a/pkg/kapp/clusterapply/add_or_update_change.go
+++ b/pkg/kapp/clusterapply/add_or_update_change.go
@@ -5,7 +5,6 @@ package clusterapply
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
@@ -236,16 +235,13 @@ func (c AddOrUpdateChange) recordAppliedResource(savedRes ctlres.Resource) error
 		}
 
 		// Record last applied change on the latest version of a resource
-		latestResWithHistoryUpdated, isAnnValueMaxLengthExceeded, err := latestResWithHistory.RecordLastAppliedResource(applyChange)
+		latestResWithHistoryUpdated, madeAnyModifications, err := latestResWithHistory.RecordLastAppliedResource(applyChange)
 		if err != nil {
-			if strings.Contains(err.Error(), "unable to record resource, limit exceed") {
-				return true, nil
-			}
 			return true, fmt.Errorf("Recording last applied resource: %s", err)
 		}
 
-		// exceed annotation value max length then don't record the resource
-		if isAnnValueMaxLengthExceeded {
+		// when annotation value max length exceed then don't record the resource hence not making any modification
+		if !madeAnyModifications {
 			return true, nil
 		}
 

--- a/pkg/kapp/clusterapply/add_or_update_change.go
+++ b/pkg/kapp/clusterapply/add_or_update_change.go
@@ -236,12 +236,17 @@ func (c AddOrUpdateChange) recordAppliedResource(savedRes ctlres.Resource) error
 		}
 
 		// Record last applied change on the latest version of a resource
-		latestResWithHistoryUpdated, err := latestResWithHistory.RecordLastAppliedResource(applyChange)
+		latestResWithHistoryUpdated, isAnnValueMaxLengthExceeded, err := latestResWithHistory.RecordLastAppliedResource(applyChange)
 		if err != nil {
 			if strings.Contains(err.Error(), "unable to record resource, limit exceed") {
 				return true, nil
 			}
 			return true, fmt.Errorf("Recording last applied resource: %s", err)
+		}
+
+		// exceed annotation value max length then don't record the resource
+		if isAnnValueMaxLengthExceeded {
+			return true, nil
 		}
 
 		_, err = c.identifiedResources.Update(latestResWithHistoryUpdated)

--- a/pkg/kapp/clusterapply/add_or_update_change.go
+++ b/pkg/kapp/clusterapply/add_or_update_change.go
@@ -5,6 +5,7 @@ package clusterapply
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
@@ -23,6 +24,10 @@ const (
 	updateStrategyFallbackOnReplaceAnnValue ClusterChangeApplyStrategyOp = "fallback-on-replace"
 	updateStrategyAlwaysReplaceAnnValue     ClusterChangeApplyStrategyOp = "always-replace"
 	updateStrategySkipAnnValue              ClusterChangeApplyStrategyOp = "skip"
+)
+
+var (
+	resourceWithHistoryDebug = os.Getenv("KAPP_DEBUG_RESOURCE_WITH_HISTORY") == "true"
 )
 
 type AddOrUpdateChangeOpts struct {
@@ -218,6 +223,28 @@ func (c AddOrUpdateChange) recordAppliedResource(savedRes ctlres.Resource) error
 		return fmt.Errorf("Calculating change after the save: %s", err)
 	}
 
+	// Use compact representation to take as little space as possible
+	// because annotation value max length is 262144 characters
+	// (https://github.com/vmware-tanzu/carvel-kapp/issues/48).
+	appliedResBytes, err := applyChange.AppliedResource().AsCompactBytes()
+	if err != nil {
+		return fmt.Errorf("Compact representation of applied resource: %s", err)
+	}
+
+	diff := applyChange.OpsDiff()
+
+	const resourceSizeMaxLen = 262144
+
+	// kapp deploy should work without adding disable annotation when resource size exceed
+	// (https://github.com/vmware-tanzu/carvel-kapp/issues/410)
+	if len(appliedResBytes) > resourceSizeMaxLen || len(diff.MinimalMD5()) > resourceSizeMaxLen {
+		if resourceWithHistoryDebug {
+			fmt.Printf("Unable to record resource, exceed limit of %d bytes (this can result in dumb diffing) \n",
+				resourceSizeMaxLen)
+		}
+		return nil
+	}
+
 	// first time, try using memory copy
 	latestResWithHistory := &savedResWithHistory
 
@@ -235,7 +262,7 @@ func (c AddOrUpdateChange) recordAppliedResource(savedRes ctlres.Resource) error
 		}
 
 		// Record last applied change on the latest version of a resource
-		latestResWithHistoryUpdated, err := latestResWithHistory.RecordLastAppliedResource(applyChange)
+		latestResWithHistoryUpdated, err := latestResWithHistory.RecordLastAppliedResource(appliedResBytes, diff)
 		if err != nil {
 			return true, fmt.Errorf("Recording last applied resource: %s", err)
 		}

--- a/pkg/kapp/diff/resource_with_history.go
+++ b/pkg/kapp/diff/resource_with_history.go
@@ -75,7 +75,7 @@ func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ct
 	// (https://github.com/vmware-tanzu/carvel-kapp/issues/48).
 	appliedResBytes, err := appliedChange.AppliedResource().AsCompactBytes()
 	if err != nil {
-		return nil, false, err
+		return nil, true, err
 	}
 
 	diff := appliedChange.OpsDiff()
@@ -104,7 +104,7 @@ func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ct
 	// (https://github.com/vmware-tanzu/carvel-kapp/issues/410)
 	for _, annVal := range annsMod.KVs {
 		if len(annVal) > annValMaxLen {
-			return nil, true, nil
+			return nil, false, nil
 		}
 	}
 
@@ -112,10 +112,10 @@ func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ct
 
 	err = annsMod.Apply(resultRes)
 	if err != nil {
-		return nil, false, err
+		return nil, true, err
 	}
 
-	return resultRes, false, nil
+	return resultRes, true, nil
 }
 
 func (r ResourceWithHistory) CalculateChange(appliedRes ctlres.Resource) (Change, error) {

--- a/pkg/kapp/diff/resource_with_history.go
+++ b/pkg/kapp/diff/resource_with_history.go
@@ -69,29 +69,16 @@ func (r ResourceWithHistory) AllowsRecordingLastApplied() bool {
 	return !found
 }
 
-func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ctlres.Resource, error) {
+func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ctlres.Resource, bool, error) {
 	// Use compact representation to take as little space as possible
 	// because annotation value max length is 262144 characters
 	// (https://github.com/vmware-tanzu/carvel-kapp/issues/48).
 	appliedResBytes, err := appliedChange.AppliedResource().AsCompactBytes()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	diff := appliedChange.OpsDiff()
-
-	const resourceSizeMaxLen = 262144
-
-	// kapp deploy should work without adding disable annotation when resource size exceed
-	// (https://github.com/vmware-tanzu/carvel-kapp/issues/410)
-	if len(appliedResBytes) > resourceSizeMaxLen || len(diff.MinimalMD5()) > resourceSizeMaxLen {
-		if resourceWithHistoryDebug {
-			fmt.Printf("Unable to record resource, exceed limit of %d bytes "+
-				"(this might result in the diff showing deletion of fields applied by external agents) \n",
-				resourceSizeMaxLen)
-		}
-		return nil, fmt.Errorf("unable to record resource, limit exceed")
-	}
 
 	if resourceWithHistoryDebug {
 		fmt.Printf("%s: recording md5 %s\n---> \n%s\n",
@@ -111,14 +98,24 @@ func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ct
 		},
 	}
 
+	const annValMaxLen = 262144
+
+	// kapp deploy should work without adding disable annotation when annotation value max length exceed
+	// (https://github.com/vmware-tanzu/carvel-kapp/issues/410)
+	for _, annVal := range annsMod.KVs {
+		if len(annVal) > annValMaxLen {
+			return nil, true, nil
+		}
+	}
+
 	resultRes := r.resource.DeepCopy()
 
 	err = annsMod.Apply(resultRes)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return resultRes, nil
+	return resultRes, false, nil
 }
 
 func (r ResourceWithHistory) CalculateChange(appliedRes ctlres.Resource) (Change, error) {


### PR DESCRIPTION
- no need to set `kapp.k14s.io/disable-original` annotation when resource size exceeds the limit of Kubernetes max annotation length. 
  - will not be recording resource in `kapp.k14s.io/original` annotation when resource limit exceeds. 
