### PR TITLE
Nothing should be changed on the cluster while doing --diff-run (#432)

### DIFF
--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -165,6 +165,11 @@ func (o *DeployOptions) Run() error {
 	}
 
 	if o.DiffFlags.Run || hasNoChanges {
+		// delete configmap created by kapp while --diff-run (#432)
+		err := app.Delete()
+		if err != nil && !hasNoChanges {
+			return fmt.Errorf("Unable to delete kapp app after diff run, %s", err)
+		}
 		if o.DiffFlags.Run && o.DiffFlags.ExitStatus {
 			return DeployDiffExitStatus{hasNoChanges}
 		}


### PR DESCRIPTION
-  deleting configmap created by kapp during `--diff-run`