### PR TITLE
Allow kapp deploy to migrate app configmap

### DIFF
--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -26,6 +26,7 @@ type App interface {
 	Exists() (bool, string, error)
 	Delete() error
 	Rename(string, string) error
+	RenamePrevApp(string, map[string]string) error
 
 	// Sorted as first is oldest
 	Changes() ([]Change, error)

--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -26,7 +26,7 @@ type App interface {
 	Exists() (bool, string, error)
 	Delete() error
 	Rename(string, string) error
-	RenamePrevApp(string, map[string]string) (string, error)
+	RenamePrevApp(string, map[string]string) error
 
 	// Sorted as first is oldest
 	Changes() ([]Change, error)

--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -26,7 +26,7 @@ type App interface {
 	Exists() (bool, string, error)
 	Delete() error
 	Rename(string, string) error
-	RenamePrevApp(string, map[string]string) error
+	RenamePrevApp(string, map[string]string) (string, error)
 
 	// Sorted as first is oldest
 	Changes() ([]Change, error)

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -70,6 +70,9 @@ func (a *LabeledApp) Delete() error {
 }
 
 func (a *LabeledApp) Rename(_ string, _ string) error { return fmt.Errorf("Not supported") }
+func (a *LabeledApp) RenamePrevApp(_ string, _ map[string]string) error {
+	return fmt.Errorf("Not supported")
+}
 
 func (a *LabeledApp) Meta() (Meta, error) { return Meta{}, nil }
 

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -70,8 +70,8 @@ func (a *LabeledApp) Delete() error {
 }
 
 func (a *LabeledApp) Rename(_ string, _ string) error { return fmt.Errorf("Not supported") }
-func (a *LabeledApp) RenamePrevApp(_ string, _ map[string]string) error {
-	return fmt.Errorf("Not supported")
+func (a *LabeledApp) RenamePrevApp(_ string, _ map[string]string) (string, error) {
+	return "", fmt.Errorf("Not supported")
 }
 
 func (a *LabeledApp) Meta() (Meta, error) { return Meta{}, nil }

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -70,8 +70,8 @@ func (a *LabeledApp) Delete() error {
 }
 
 func (a *LabeledApp) Rename(_ string, _ string) error { return fmt.Errorf("Not supported") }
-func (a *LabeledApp) RenamePrevApp(_ string, _ map[string]string) (string, error) {
-	return "", fmt.Errorf("Not supported")
+func (a *LabeledApp) RenamePrevApp(_ string, _ map[string]string) error {
+	return fmt.Errorf("Not supported")
 }
 
 func (a *LabeledApp) Meta() (Meta, error) { return Meta{}, nil }

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -191,12 +191,7 @@ func (a *RecordedApp) createOrUpdate(c *corev1.ConfigMap, labels map[string]stri
 				return fmt.Errorf("Getting app: %s", err)
 			}
 
-			err = a.updateApp(existingConfigMap, labels)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return a.updateApp(existingConfigMap, labels)
 		}
 
 		return fmt.Errorf("Creating app: %s", err)

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -214,7 +214,7 @@ func (a *RecordedApp) updateApp(existingConfigMap *corev1.ConfigMap, labels map[
 	return nil
 }
 
-func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string) error {
+func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string) (string, error) {
 	defer a.logger.DebugFunc("RenamePrevApp").Finish()
 	var c *corev1.ConfigMap
 	var err error
@@ -222,19 +222,19 @@ func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string
 	if a.isMigrationEnabled() {
 		c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), a.fqName, metav1.GetOptions{})
 		if err == nil {
-			return a.updateApp(c, labels)
+			return "", a.updateApp(c, labels)
 		} else if err != nil {
 			if errors.IsNotFound(err) {
 				c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), a.name, metav1.GetOptions{})
 				if err == nil {
-					return a.migrate(c, labels, a.fqName)
+					return "", a.migrate(c, labels, a.fqName)
 				}
 			}
 		}
 	} else {
 		c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), a.name, metav1.GetOptions{})
 		if err == nil {
-			return a.updateApp(c, labels)
+			return "", a.updateApp(c, labels)
 		}
 	}
 
@@ -242,12 +242,13 @@ func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string
 		if a.isMigrationEnabled() {
 			c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), prevAppName+AppSuffix, metav1.GetOptions{})
 			if err == nil {
-				return a.migrate(c, labels, a.fqName)
+				return "", a.migrate(c, labels, a.fqName)
 			} else if err != nil {
 				if errors.IsNotFound(err) {
 					c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), prevAppName, metav1.GetOptions{})
 					if err == nil {
-						return a.migrate(c, labels, a.fqName)
+						msg := fmt.Sprintf("Renaming '%s' (namespace: %s) to '%s' (app changes will not be renamed)", prevAppName, c.Namespace, a.name)
+						return msg, a.migrate(c, labels, a.fqName)
 					}
 				}
 			}
@@ -256,19 +257,20 @@ func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string
 			if err == nil {
 				err := a.renameConfigMap(c, a.name, a.nsName)
 				if err != nil {
-					return err
+					return "", err
 				}
 
-				return a.updateApp(c, labels)
+				msg := fmt.Sprintf("Renaming '%s' (namespace: %s) to '%s' (app changes will not be renamed)", prevAppName, c.Namespace, a.name)
+				return msg, a.updateApp(c, labels)
 			}
 		}
 
 		if errors.IsNotFound(err) {
-			return a.CreateOrUpdate(labels)
+			return "", a.CreateOrUpdate(labels)
 		}
 	}
 
-	return err
+	return "", err
 }
 
 func (a *RecordedApp) migrate(c *corev1.ConfigMap, labels map[string]string, newName string) error {

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -139,17 +139,7 @@ func (a *RecordedApp) CreateOrUpdate(labels map[string]string) error {
 		configMapWithSuffix, err := a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), a.fqName, metav1.GetOptions{})
 		if err == nil {
 			if a.isKappApp(configMapWithSuffix) {
-				err = a.mergeAppUpdates(configMapWithSuffix, labels)
-				if err != nil {
-					return err
-				}
-
-				_, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Update(context.TODO(), configMapWithSuffix, metav1.UpdateOptions{})
-				if err != nil {
-					return fmt.Errorf("Updating app: %s", err)
-				}
-
-				return nil
+				return a.updateApp(configMapWithSuffix, labels)
 			}
 		} else if !errors.IsNotFound(err) {
 			// return if error is anything other than configmap not found

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -227,7 +227,9 @@ func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string
 	if a.isMigrationEnabled() {
 		c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), a.fqName, metav1.GetOptions{})
 		if err == nil {
-			return a.updateApp(c, labels)
+			if a.isKappApp(c) {
+				return a.updateApp(c, labels)
+			}
 		} else if err != nil {
 			if errors.IsNotFound(err) {
 				c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), a.name, metav1.GetOptions{})
@@ -247,7 +249,9 @@ func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string
 		if a.isMigrationEnabled() {
 			c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), prevAppName+AppSuffix, metav1.GetOptions{})
 			if err == nil {
-				return a.migrate(c, labels, a.fqName)
+				if a.isKappApp(c) {
+					return a.migrate(c, labels, a.fqName)
+				}
 			} else if err != nil {
 				if errors.IsNotFound(err) {
 					c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), prevAppName, metav1.GetOptions{})

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -254,7 +254,12 @@ func (a *RecordedApp) RenamePrevApp(prevAppName string, labels map[string]string
 		} else {
 			c, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Get(context.TODO(), prevAppName, metav1.GetOptions{})
 			if err == nil {
-				return a.migrate(c, labels, a.name)
+				err := a.renameConfigMap(c, a.name, a.nsName)
+				if err != nil {
+					return err
+				}
+
+				return a.updateApp(c, labels)
 			}
 		}
 

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -96,8 +96,9 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
+	var msg string = ""
 	if o.DeployFlags.PrevApp != "" {
-		err = app.RenamePrevApp(o.DeployFlags.PrevApp, appLabels)
+		msg, err = app.RenamePrevApp(o.DeployFlags.PrevApp, appLabels)
 	} else {
 		err = app.CreateOrUpdate(appLabels)
 	}
@@ -177,6 +178,10 @@ func (o *DeployOptions) Run() error {
 			return DeployApplyExitStatus{hasNoChanges}
 		}
 		return nil
+	}
+
+	if msg != "" {
+		o.ui.PrintLinef(msg)
 	}
 
 	err = o.ui.AskForConfirmation()

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -96,9 +96,8 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
-	var msg string = ""
 	if o.DeployFlags.PrevApp != "" {
-		msg, err = app.RenamePrevApp(o.DeployFlags.PrevApp, appLabels)
+		err = app.RenamePrevApp(o.DeployFlags.PrevApp, appLabels)
 	} else {
 		err = app.CreateOrUpdate(appLabels)
 	}
@@ -178,10 +177,6 @@ func (o *DeployOptions) Run() error {
 			return DeployApplyExitStatus{hasNoChanges}
 		}
 		return nil
-	}
-
-	if msg != "" {
-		o.ui.PrintLinef(msg)
 	}
 
 	err = o.ui.AskForConfirmation()

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -96,7 +96,12 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
-	err = app.CreateOrUpdate(appLabels)
+	if o.DeployFlags.PrevApp != "" {
+		err = app.RenamePrevApp(o.DeployFlags.PrevApp, appLabels)
+	} else {
+		err = app.CreateOrUpdate(appLabels)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/deploy_flags.go
+++ b/pkg/kapp/cmd/app/deploy_flags.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	ctlapp "github.com/k14s/kapp/pkg/kapp/app"
@@ -18,6 +19,7 @@ type DeployFlags struct {
 	ExistingNonLabeledResourcesCheck            bool
 	ExistingNonLabeledResourcesCheckConcurrency int
 	OverrideOwnershipOfExistingResources        bool
+	PrevApp                                     string
 
 	AppChangesMaxToKeep int
 
@@ -43,6 +45,7 @@ func (s *DeployFlags) Set(cmd *cobra.Command) {
 		100, "Concurrency to check for existing non-labeled resources")
 	cmd.Flags().BoolVar(&s.OverrideOwnershipOfExistingResources, "dangerous-override-ownership-of-existing-resources",
 		false, "Steal existing resources from another app")
+	cmd.Flags().StringVar(&s.PrevApp, "prev-app", "", "Rename existing app")
 
 	cmd.Flags().IntVar(&s.AppChangesMaxToKeep, "app-changes-max-to-keep", ctlapp.AppChangesMaxToKeepDefault, "Maximum number of app changes to keep")
 

--- a/pkg/kapp/cmd/app/deploy_flags.go
+++ b/pkg/kapp/cmd/app/deploy_flags.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 
 	ctlapp "github.com/k14s/kapp/pkg/kapp/app"

--- a/pkg/kapp/cmd/app/deploy_flags.go
+++ b/pkg/kapp/cmd/app/deploy_flags.go
@@ -5,9 +5,9 @@ package app
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 
 	ctlapp "github.com/k14s/kapp/pkg/kapp/app"
+	"github.com/spf13/cobra"
 )
 
 type DeployFlags struct {

--- a/test/e2e/create_update_delete_test.go
+++ b/test/e2e/create_update_delete_test.go
@@ -4,9 +4,11 @@
 package e2e
 
 import (
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/k14s/kapp/pkg/kapp/app"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	"github.com/stretchr/testify/require"
 )
@@ -91,4 +93,293 @@ data:
 		NewMissingClusterResource(t, "configmap", "redis-config", env.Namespace, kubectl)
 		NewMissingClusterResource(t, "configmap", "redis-config2", env.Namespace, kubectl)
 	})
+}
+
+func TestCreateUpdateDelete_PrevApp(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	yaml1 := `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-primary
+spec:
+  ports:
+  - port: 6380
+    targetPort: 6380
+  selector:
+    app: redis
+    tier: backend
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+data:
+  key: value
+`
+
+	yaml2 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+data:
+  key: value2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config2
+data:
+  key: value
+`
+
+	appName := "test-create-update-delete-prev-app"
+	prevAppName := "test-create-update-delete-prev-app-old"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", appName})
+		os.Unsetenv("KAPP_FQ_CONFIGMAP_NAMES")
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("prevApp does not exist", func() {
+		logger.Section("deploy initial", func() {
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+			NewPresentClusterResource("service", "redis-primary", env.Namespace, kubectl)
+			NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+
+			NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+
+		logger.Section("deploy update with 1 delete, 1 update, 1 create", func() {
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+
+			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+
+			config := NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+			val := config.RawPath(ctlres.NewPathFromStrings([]string{"data", "key"}))
+
+			require.Exactlyf(t, "value2", val, "Expected value to be updated")
+
+			NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
+
+			NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+
+		logger.Section("delete application", func() {
+			kapp.RunWithOpts([]string{"delete", "-a", appName}, RunOpts{})
+
+			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config2", env.Namespace, kubectl)
+
+			NewMissingClusterResource(t, "configmap", appName, env.Namespace, kubectl)
+		})
+	})
+
+	logger.Section("prevApp does exist", func() {
+		logger.Section("deploy", func() {
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+			NewPresentClusterResource("service", "redis-primary", env.Namespace, kubectl)
+			NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+			NewPresentClusterResource("configmap", prevAppName, env.Namespace, kubectl)
+
+			// migrate
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+
+			config := NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+			val := config.RawPath(ctlres.NewPathFromStrings([]string{"data", "key"}))
+			require.Exactlyf(t, "value2", val, "Expected value to be updated")
+
+			NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
+
+			NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+
+		logger.Section("delete application", func() {
+			kapp.RunWithOpts([]string{"delete", "-a", appName}, RunOpts{})
+
+			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config2", env.Namespace, kubectl)
+
+			NewMissingClusterResource(t, "configmap", appName, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+	})
+}
+
+func TestCreateUpdateDelete_PrevApp_FQConfigmap_Enabled(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	yaml1 := `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-primary
+spec:
+  ports:
+  - port: 6380
+    targetPort: 6380
+  selector:
+    app: redis
+    tier: backend
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+data:
+  key: value
+`
+
+	yaml2 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+data:
+  key: value2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config2
+data:
+  key: value
+`
+
+	appName := "test-create-update-delete-prev-app-fq-configmap"
+	prevAppName := "test-create-update-delete-prev-app-fq-configmap-old"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", appName})
+		os.Unsetenv("KAPP_FQ_CONFIGMAP_NAMES")
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "True")
+
+	logger.Section("prevApp does not exist", func() {
+		logger.Section("deploy initial", func() {
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+			NewPresentClusterResource("service", "redis-primary", env.Namespace, kubectl)
+			NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+
+			NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+
+		logger.Section("deploy update with 1 delete, 1 update, 1 create", func() {
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+
+			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+
+			config := NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+			val := config.RawPath(ctlres.NewPathFromStrings([]string{"data", "key"}))
+
+			require.Exactlyf(t, "value2", val, "Expected value to be updated")
+
+			NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
+
+			c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+			require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+
+		logger.Section("delete application", func() {
+			kapp.RunWithOpts([]string{"delete", "-a", appName}, RunOpts{})
+
+			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config2", env.Namespace, kubectl)
+
+			NewMissingClusterResource(t, "configmap", appName, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		})
+	})
+
+	logger.Section("prevApp exists", func() {
+		logger.Section("deploy", func() {
+			os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "False")
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+			// migrate
+			os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "True")
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+
+			config := NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+			val := config.RawPath(ctlres.NewPathFromStrings([]string{"data", "key"}))
+			require.Exactlyf(t, "value2", val, "Expected value to be updated")
+
+			NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
+
+			c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+			require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+
+		logger.Section("delete application", func() {
+			kapp.RunWithOpts([]string{"delete", "-a", appName}, RunOpts{})
+
+			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config", env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", "redis-config2", env.Namespace, kubectl)
+
+			NewMissingClusterResource(t, "configmap", appName, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
+		})
+	})
+
+	// logger.Section("prevApp exists and migrated", func() {
+	// 	logger.Section("deploy", func() {
+	// 		os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "True")
+	// 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+	// 		// migrate
+	// 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+
+	// 		config := NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
+	// 		val := config.RawPath(ctlres.NewPathFromStrings([]string{"data", "key"}))
+	// 		require.Exactlyf(t, "value2", val, "Expected value to be updated")
+
+	// 		NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
+
+	// 		c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+	// 		require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+	// 		NewMissingClusterResource(t, "configmap", prevAppName+app.AppSuffix, env.Namespace, kubectl)
+	// 	})
+
+	// 	logger.Section("delete application", func() {
+	// 		kapp.RunWithOpts([]string{"delete", "-a", appName}, RunOpts{})
+
+	// 		NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
+	// 		NewMissingClusterResource(t, "configmap", "redis-config", env.Namespace, kubectl)
+	// 		NewMissingClusterResource(t, "configmap", "redis-config2", env.Namespace, kubectl)
+
+	// 		NewMissingClusterResource(t, "configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+	// 		NewMissingClusterResource(t, "configmap", prevAppName+app.AppSuffix, env.Namespace, kubectl)
+	// 	})
+	// })
 }

--- a/test/e2e/create_update_delete_test.go
+++ b/test/e2e/create_update_delete_test.go
@@ -158,14 +158,15 @@ data:
 		NewPresentClusterResource("service", "redis-primary", env.Namespace, kubectl)
 		NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
 
-		NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+		c := NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+		require.NotContains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
 
 		cleanUp()
 	})
 
 	logger.Section("existing unmigrated app", func() {
 		logger.Section("deploy", func() {
-			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 			kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 
 			NewMissingClusterResource(t, "service", "redis-primary", env.Namespace, kubectl)
@@ -177,7 +178,9 @@ data:
 
 			NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
 
-			NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+			c := NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+			require.NotContains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+
 			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
 		})
 
@@ -218,7 +221,9 @@ data:
 
 		NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
 
-		NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+		c := NewPresentClusterResource("configmap", appName, env.Namespace, kubectl)
+		require.NotContains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+
 		NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
 
 		cleanUp()
@@ -306,7 +311,8 @@ data:
 		NewPresentClusterResource("service", "redis-primary", env.Namespace, kubectl)
 		NewPresentClusterResource("configmap", "redis-config", env.Namespace, kubectl)
 
-		NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
 
 		cleanUp()
 	})
@@ -325,7 +331,9 @@ data:
 
 			NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
 
-			NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+			c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+			require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+
 			NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
 		})
 
@@ -342,7 +350,8 @@ data:
 
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 
-		NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
 
 		cleanUp()
 	})
@@ -359,7 +368,9 @@ data:
 
 		NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
 
-		NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+
 		NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
 
 		cleanUp()
@@ -377,7 +388,9 @@ data:
 
 		NewPresentClusterResource("configmap", "redis-config2", env.Namespace, kubectl)
 
-		NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		c := NewPresentClusterResource("configmap", appName+app.AppSuffix, env.Namespace, kubectl)
+		require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
+
 		NewMissingClusterResource(t, "configmap", prevAppName, env.Namespace, kubectl)
 
 		cleanUp()


### PR DESCRIPTION
Following on from https://github.com/vmware-tanzu/carvel-kapp/issues/146, this PR introduces a new flag (`--prev-app`) on the `deploy` command.

This `--prev-app` command performs the functionality of `kapp rename` but within the `deploy` command, this is important for controllers such as `kapp-controller` that cannot introduce another command on every reconciliation loop. The purpose of this flag is to optimize the `deploy` case to handle renaming / migrating when necessary without needing `kapp rename`.

This flag also interacts with the recently introduced `KAPP_FQ_CONFIGMAP_NAMES` environment variable. The tests cases are therefore pretty extensive to cover all the various ways these options can be used together. There are two main useful test cases that explicity expect a failure:

1. An app has been migrated previously, and now the user has not set `KAPP_FQ_CONFIGMAP_NAMES` or explicity set it to `false`
- https://github.com/vmware-tanzu/carvel-kapp/pull/450/files#diff-019ca500f7c4cf4ec2758417db106bda75824729b9a3884a797c6719e76714ddR192-R210
- https://github.com/vmware-tanzu/carvel-kapp/pull/450/files#diff-019ca500f7c4cf4ec2758417db106bda75824729b9a3884a797c6719e76714ddR228-R242
2. The reason for this is mainly due to the complexity of allowing migrations back and forth, the codebase is not setup in a way that this plays out nicely. Let me know if this is a deal breaker and we can work out some way to make it possible to do.

Let me know if you have any questions!

For more information / details, checkout the [doc](https://docs.google.com/document/d/1gE-gwrTeYSZ91zPYcjalwMp-zMJSOwNW1wSPTKYxLcQ/edit?usp=sharing)

Signed-off-by: Neil Hickey <nhickey@vmware.com>