### PR TITLE
#446: updated kapp timeout error. Will list resource's description fo…

### DIFF
--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -5,6 +5,7 @@ package clusterapply
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	ctldgraph "github.com/k14s/kapp/pkg/kapp/diffgraph"
@@ -119,11 +120,11 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 		}
 
 		if time.Now().Sub(startTime) > c.opts.Timeout {
-			trackedResourcesDesc := ""
+			var timedOutResources []string
 			for _, change := range c.trackedChanges {
-				trackedResourcesDesc = trackedResourcesDesc + change.Graph.Change.Resource().Description() + "\n "
+				timedOutResources = append(timedOutResources, change.Graph.Change.Resource().Description())
 			}
-			return nil, fmt.Errorf("Timed out waiting after %s for resources:\n %+v", c.opts.Timeout, trackedResourcesDesc)
+			return nil, fmt.Errorf("Timed out waiting after %s for resources:\n %s", c.opts.Timeout, strings.Join(timedOutResources, "\n "))
 		}
 
 		time.Sleep(c.opts.CheckInterval)

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -117,9 +117,13 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 		if len(c.trackedChanges) == 0 || len(doneChanges) > 0 {
 			return doneChanges, nil
 		}
+		trackedResourcesDesc := ""
 
+		for _, change := range c.trackedChanges {
+			trackedResourcesDesc = trackedResourcesDesc + change.Graph.Change.Resource().Description() + "\n "
+		}
 		if time.Now().Sub(startTime) > c.opts.Timeout {
-			return nil, fmt.Errorf("Timed out waiting after %s", c.opts.Timeout)
+			return nil, fmt.Errorf("Timed out waiting after %s for resources:\n %+v", c.opts.Timeout, trackedResourcesDesc)
 		}
 
 		time.Sleep(c.opts.CheckInterval)

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -117,12 +117,12 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 		if len(c.trackedChanges) == 0 || len(doneChanges) > 0 {
 			return doneChanges, nil
 		}
-		trackedResourcesDesc := ""
 
-		for _, change := range c.trackedChanges {
-			trackedResourcesDesc = trackedResourcesDesc + change.Graph.Change.Resource().Description() + "\n "
-		}
 		if time.Now().Sub(startTime) > c.opts.Timeout {
+			trackedResourcesDesc := ""
+			for _, change := range c.trackedChanges {
+				trackedResourcesDesc = trackedResourcesDesc + change.Graph.Change.Resource().Description() + "\n "
+			}
 			return nil, fmt.Errorf("Timed out waiting after %s for resources:\n %+v", c.opts.Timeout, trackedResourcesDesc)
 		}
 

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	uierrs "github.com/cppforlife/go-cli-ui/errors"
 	ctldgraph "github.com/k14s/kapp/pkg/kapp/diffgraph"
 	ctlresm "github.com/k14s/kapp/pkg/kapp/resourcesmisc"
 	"github.com/k14s/kapp/pkg/kapp/util"
@@ -122,9 +123,9 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 		if time.Now().Sub(startTime) > c.opts.Timeout {
 			var timedOutResources []string
 			for _, change := range c.trackedChanges {
-				timedOutResources = append(timedOutResources, change.Graph.Change.Resource().Description())
+				timedOutResources = append(timedOutResources, change.Cluster.Resource().Description())
 			}
-			return nil, fmt.Errorf("Timed out waiting after %s for resources:\n %s", c.opts.Timeout, strings.Join(timedOutResources, "\n "))
+			return nil, uierrs.NewSemiStructuredError(fmt.Errorf("Timed out waiting after %s for resources: [%s]", c.opts.Timeout, strings.Join(timedOutResources, ", ")))
 		}
 
 		time.Sleep(c.opts.CheckInterval)

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -121,11 +121,11 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 		}
 
 		if time.Now().Sub(startTime) > c.opts.Timeout {
-			var timedOutResources []string
+			var trackedResourcesDesc []string
 			for _, change := range c.trackedChanges {
-				timedOutResources = append(timedOutResources, change.Cluster.Resource().Description())
+				trackedResourcesDesc = append(trackedResourcesDesc, change.Cluster.Resource().Description())
 			}
-			return nil, uierrs.NewSemiStructuredError(fmt.Errorf("Timed out waiting after %s for resources: [%s]", c.opts.Timeout, strings.Join(timedOutResources, ", ")))
+			return nil, uierrs.NewSemiStructuredError(fmt.Errorf("Timed out waiting after %s for resources: [%s]", c.opts.Timeout, strings.Join(trackedResourcesDesc, ", ")))
 		}
 
 		time.Sleep(c.opts.CheckInterval)


### PR DESCRIPTION
Updated kapp timeout error. Will list resource's description for which timeout is happening in error log.

Error will look like:
```
$ ./kapp delete -a app1                                            
Target cluster 'https://127.0.0.1:56202' (nodes: minikube)

Changes

Namespace  Name                         Kind           Age  Op      Op st.  Wait to  Rs  Ri  
default    simple-app                   Deployment     3s   delete  -       delete   ok  -  
^          simple-app                   Endpoints      3s   -       -       delete   ok  -  
^          simple-app                   Service        3s   delete  -       delete   ok  -  
^          simple-app-4prws             EndpointSlice  3s   -       -       delete   ok  -  
^          simple-app-64f85bbb96        ReplicaSet     3s   -       -       delete   ok  -  
^          simple-app-64f85bbb96-8g8q7  Pod            3s   -       -       delete   ok  -  

Op:      0 create, 2 delete, 0 update, 4 noop, 0 exists
Wait to: 0 reconcile, 6 delete, 0 noop

Continue? [yN]: y

9:48:40AM: ---- applying 6 changes [0/6 done] ----
9:48:40AM: noop replicaset/simple-app-1-684f6ff85c (apps/v1) namespace: default
9:48:40AM: noop endpointslice/simple-app-1-qpp9h (discovery.k8s.io/v1) namespace: default
9:48:40AM: noop endpoints/simple-app-1 (v1) namespace: default
9:48:40AM: noop pod/simple-app-1-684f6ff85c-gq9vv (v1) namespace: default
9:48:40AM: delete deployment/simple-app-1 (apps/v1) namespace: default
9:48:40AM: delete service/simple-app-1 (v1) namespace: default
9:48:40AM: ---- waiting on 6 changes [0/6 done] ----
9:48:40AM: ok: delete service/simple-app-1 (v1) namespace: default
9:48:40AM: ongoing: delete endpointslice/simple-app-1-qpp9h (discovery.k8s.io/v1) namespace: default
9:48:40AM: ongoing: delete pod/simple-app-1-684f6ff85c-gq9vv (v1) namespace: default
9:48:40AM: ok: delete endpoints/simple-app-1 (v1) namespace: default
9:48:40AM: ongoing: delete replicaset/simple-app-1-684f6ff85c (apps/v1) namespace: default
9:48:40AM: ok: delete deployment/simple-app-1 (apps/v1) namespace: default
9:48:40AM: ---- waiting on 3 changes [3/6 done] ----

kapp: Error: Timed out waiting after 1µs for resources: 

  - replicaset/simple-app-1-684f6ff85c (apps/v1) namespace: default

  - endpointslice/simple-app-1-qpp9h (discovery.k8s.io/v1) namespace: default

  - pod/simple-app-1-684f6ff85c-gq9vv (v1) namespace: default
```