### PR TITLE
WIP - Add non-blocking-wait annotation

### DIFF
--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	nonBlockingOrderingAnnKey = "kapp.k14s.io/non-blocking-ordering" // value is ignored
+	nonBlockingWaitAnnKey = "kapp.k14s.io/non-blocking-wait" // value is ignored
 )
 
 type WaitingChangesOpts struct {
@@ -105,7 +105,7 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 			case !state.Done:
 				newInProgressChanges = append(newInProgressChanges, change)
 
-				if _, found := change.Cluster.Resource().Annotations()[nonBlockingOrderingAnnKey]; found {
+				if _, found := change.Cluster.Resource().Annotations()[nonBlockingWaitAnnKey]; found {
 					// TODO Improve if condition
 					if !strings.Contains(state.Message, "Waiting for generation") {
 						doneChanges = append(doneChanges, change)

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -5,7 +5,6 @@ package clusterapply
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	ctldgraph "github.com/k14s/kapp/pkg/kapp/diffgraph"
@@ -106,10 +105,7 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 				newInProgressChanges = append(newInProgressChanges, change)
 
 				if _, found := change.Cluster.Resource().Annotations()[nonBlockingWaitAnnKey]; found {
-					// TODO Improve if condition
-					if !strings.Contains(state.Message, "Waiting for generation") {
-						doneChanges = append(doneChanges, change)
-					}
+					doneChanges = append(doneChanges, change)
 				}
 
 			case state.Done && !state.Successful:

--- a/test/e2e/order_test.go
+++ b/test/e2e/order_test.go
@@ -259,9 +259,9 @@ metadata:
 
 		expectedOutput := strings.TrimSpace(replaceSpaces(`Changes
 
-Namespace  Name            Kind       Conds.  Age  Op      Op st.  Wait to    Rs  Ri  $
-kapp-test  resource-2      ConfigMap  -       -    create  -       reconcile  -   -  $
-^          successful-job  Job        -       -    create  -       reconcile  -   -  $
+Namespace  Name            Kind       Age  Op      Op st.  Wait to    Rs  Ri  $
+kapp-test  resource-2      ConfigMap  -    create  -       reconcile  -   -  $
+^          successful-job  Job        -    create  -       reconcile  -   -  $
 
 Op:      2 create, 0 delete, 0 update, 0 noop, 0 exists
 Wait to: 2 reconcile, 0 delete, 0 noop


### PR DESCRIPTION
Add non-blocking-wait annotation to enable disable waiting of a resource by the dependent resources.
Example: 
```
---
kind: Deployment
name: dep-1
...
    kapp.k14s.io/change-group: "group-1"
    kapp.k14s.io/non-blocking-wait: ""
...
---
kind: ConfigMap
name: cm-1
...
    kapp.k14s.io/change-rule: "upsert after upserting group-1"
...
```
```
...
---- applying 1 changes [0/2 done] ----
create deployment/dep-1 (batch/v1) namespace: default
---- waiting on 1 changes [0/2 done] ----
ongoing: reconcile deployment/dep-1 (batch/v1) namespace: default
^ Waiting to complete (0 active, 0 failed, 0 succeeded)
---- applying 1 changes [1/2 done] ----
create configmap/cm-1 (v1) namespace: default
---- waiting on 2 changes [0/2 done] ----
...
```
