### PR TITLE
Fix crash when applying rebase rule for nil map key

### DIFF
--- a/pkg/kapp/diff/change_set_test.go
+++ b/pkg/kapp/diff/change_set_test.go
@@ -267,7 +267,7 @@ metadata:
 	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
 }
 
-func TestChangeSet_RebaseWithNilNew_And_UnexpectedChanges(t *testing.T) {
+func TestRebaseWithNilNewAndUnexpectedChanges(t *testing.T) {
 	newRes := ctlres.MustNewResourceFromBytes([]byte(`
 metadata:
   name: my-res

--- a/pkg/kapp/diff/change_set_test.go
+++ b/pkg/kapp/diff/change_set_test.go
@@ -266,3 +266,60 @@ metadata:
 
 	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
 }
+
+func TestChangeSet_RebaseWithNilNew_And_UnexpectedChanges(t *testing.T) {
+	newRes := ctlres.MustNewResourceFromBytes([]byte(`
+metadata:
+  name: my-res
+  annotations:
+`))
+
+	existingRes := ctlres.MustNewResourceFromBytes([]byte(`
+metadata:
+  name: my-res
+  annotations:
+    unexpected: "1"
+    rebased: "1"
+`))
+
+	mods := []ctlres.ResourceModWithMultiple{
+		ctlres.FieldCopyMod{
+			ResourceMatcher: ctlres.AllMatcher{},
+			Path:            ctlres.NewPathFromStrings([]string{"metadata"}),
+			Sources:         []ctlres.FieldCopyModSource{ctlres.FieldCopyModSourceExisting},
+		},
+		ctlres.FieldRemoveMod{
+			ResourceMatcher: ctlres.AllMatcher{},
+			Path:            ctlres.NewPathFromStrings([]string{"metadata", "annotations"}),
+		},
+		ctlres.FieldCopyMod{
+			ResourceMatcher: ctlres.AllMatcher{},
+			Path:            ctlres.NewPathFromStrings([]string{"metadata", "annotations"}),
+			Sources:         []ctlres.FieldCopyModSource{ctlres.FieldCopyModSourceNew},
+		},
+		ctlres.FieldCopyMod{
+			ResourceMatcher: ctlres.AllMatcher{},
+			Path:            ctlres.NewPathFromStrings([]string{"metadata", "annotations", "rebased"}),
+			Sources:         []ctlres.FieldCopyModSource{ctlres.FieldCopyModSourceNew, ctlres.FieldCopyModSourceExisting},
+		},
+	}
+
+	changeFactory := ctldiff.NewChangeFactory(mods, nil)
+	changeSet := ctldiff.NewChangeSet([]ctlres.Resource{existingRes}, []ctlres.Resource{newRes},
+		ctldiff.ChangeSetOpts{}, changeFactory)
+
+	changes, err := changeSet.Calculate()
+	require.NoError(t, err)
+
+	actualDiff := changes[0].ConfigurableTextDiff().Full().FullString()
+
+	expectedDiff := strings.Replace(`  0,  0   metadata:
+  1,  1     annotations:
+  2,  2       rebased: "1"
+  3,  3 -     unexpected: "1"
+  4,  3     name: my-res
+  5,  4   <---space
+`, "<---space", "", -1)
+
+	require.Equal(t, expectedDiff, actualDiff, "Expected diff to match")
+}

--- a/pkg/kapp/diff/rebased_resource.go
+++ b/pkg/kapp/diff/rebased_resource.go
@@ -42,7 +42,7 @@ func (r RebasedResource) Resource() (ctlres.Resource, error) {
 	}
 
 	for _, t := range r.mods {
-		// copy newRes and existingRes as they may be be modified in place
+		// copy newRes and existingRes as they may be modified in place
 		resSources := map[ctlres.FieldCopyModSource]ctlres.Resource{
 			ctlres.FieldCopyModSourceNew:      r.newRes.DeepCopy(),
 			ctlres.FieldCopyModSourceExisting: r.existingRes.DeepCopy(),

--- a/pkg/kapp/resources/mod_field_copy.go
+++ b/pkg/kapp/resources/mod_field_copy.go
@@ -161,7 +161,7 @@ func (t FieldCopyMod) obtainValue(obj interface{}, path Path) (interface{}, bool
 		switch {
 		case part.MapKey != nil:
 			typedObj, ok := obj.(map[string]interface{})
-			if !ok {
+			if !ok && typedObj != nil {
 				return nil, false, fmt.Errorf("Unexpected non-map found: %T", obj)
 			}
 


### PR DESCRIPTION
Found an issue when attempting to apply the Rancher 2.6 Helm chart via kapp.

The template for the deployment has logic which can result in an empty/nil value for the `annotations` metadata key.

```
metadata:
  name: {{ template "rancher.fullname" . }}
  annotations:
{{- if (lt (int .Values.replicas) 0) }}
    management.cattle.io/scale-available: "{{ sub 0 (int .Values.replicas)}}"
{{- end  }}
  labels:
{{ include "rancher.labels" . | indent 4 }}
```

kapp is unable to deploy the chart when the annotations are empty, throwing this error:

```
kapp: Error: Applying rebase rule to deployment/rancher (apps/v1) namespace: cattle-system:
  FieldCopyMod for path 'metadata,annotations,deployment.kubernetes.io/revision' on resource 'deployment/rancher (apps/v1) namespace: cattle-system':
    Unexpected non-map found: <nil>
```

The type checking for key values should allow nil, as a map can fully overwrite the empty value.