### PR TITLE
Moving the call to VisitCommands down except DisallowExtraArgs.

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -5,8 +5,7 @@ set -e -x -u
 go clean -testcache
 
 export KAPP_BINARY_PATH="${KAPP_BINARY_PATH:-$PWD/kapp}"
-export KAPP_E2E_NAMESPACE="kapp-test"
-kubectl create ns $KAPP_E2E_NAMESPACE
+
 go test ./test/e2e/ -timeout 60m -test.v $@
 
 echo E2E SUCCESS

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -5,7 +5,8 @@ set -e -x -u
 go clean -testcache
 
 export KAPP_BINARY_PATH="${KAPP_BINARY_PATH:-$PWD/kapp}"
-
+export KAPP_E2E_NAMESPACE="kapp-test"
+kubectl create ns $KAPP_E2E_NAMESPACE
 go test ./test/e2e/ -timeout 60m -test.v $@
 
 echo E2E SUCCESS

--- a/pkg/kapp/cmd/kapp.go
+++ b/pkg/kapp/cmd/kapp.go
@@ -138,16 +138,16 @@ func NewKappCmd(o *KappOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		return nil
 	})
 
-	// Last one runs first
-	cobrautil.VisitCommands(cmd, finishDebugLog, cobrautil.ReconfigureCmdWithSubcmd,
-		cobrautil.ReconfigureLeafCmds(cobrautil.DisallowExtraArgs), cobrautil.WrapRunEForCmd(cobrautil.ResolveFlagsForCmd))
+	cobrautil.VisitCommands(cmd, cobrautil.ReconfigureLeafCmds(cobrautil.DisallowExtraArgs))
 
-	// Completion command have to be added after the VisitCommands
+	// Completion command have to be added after the cobrautil.DisallowExtraArgs.
 	// This due to the ReconfigureLeafCmds that we do not want to have enforced for the completion
 	// This configurations forces all nodes to do not accept extra args, but the completion requires 1 extra arg
 	cmd.AddCommand(NewCmdCompletion())
 
-	cobrautil.VisitCommands(cmd, configureGlobal)
+	// Last one runs first
+	cobrautil.VisitCommands(cmd, finishDebugLog, cobrautil.ReconfigureCmdWithSubcmd, configureGlobal, cobrautil.WrapRunEForCmd(cobrautil.ResolveFlagsForCmd))
+
 	return cmd
 }
 

--- a/pkg/kapp/cmd/kapp.go
+++ b/pkg/kapp/cmd/kapp.go
@@ -147,7 +147,6 @@ func NewKappCmd(o *KappOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 
 	// Last one runs first
 	cobrautil.VisitCommands(cmd, finishDebugLog, cobrautil.ReconfigureCmdWithSubcmd, configureGlobal, cobrautil.WrapRunEForCmd(cobrautil.ResolveFlagsForCmd))
-
 	return cmd
 }
 

--- a/pkg/kapp/cmd/kapp.go
+++ b/pkg/kapp/cmd/kapp.go
@@ -140,12 +140,14 @@ func NewKappCmd(o *KappOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 
 	// Last one runs first
 	cobrautil.VisitCommands(cmd, finishDebugLog, cobrautil.ReconfigureCmdWithSubcmd,
-		cobrautil.ReconfigureLeafCmds(cobrautil.DisallowExtraArgs), configureGlobal, cobrautil.WrapRunEForCmd(cobrautil.ResolveFlagsForCmd))
+		cobrautil.ReconfigureLeafCmds(cobrautil.DisallowExtraArgs), cobrautil.WrapRunEForCmd(cobrautil.ResolveFlagsForCmd))
 
 	// Completion command have to be added after the VisitCommands
 	// This due to the ReconfigureLeafCmds that we do not want to have enforced for the completion
 	// This configurations forces all nodes to do not accept extra args, but the completion requires 1 extra arg
 	cmd.AddCommand(NewCmdCompletion())
+
+	cobrautil.VisitCommands(cmd, configureGlobal)
 	return cmd
 }
 


### PR DESCRIPTION
Moving the call to VisitCommands down except DisallowExtraArgs, as it should happen for kapp completion bash command also.