### PR TITLE
452: handle delete strategy for inoperable resources

### DIFF
--- a/pkg/kapp/clusterapply/delete_change.go
+++ b/pkg/kapp/clusterapply/delete_change.go
@@ -44,6 +44,18 @@ var inoperableResourceList = []uniqueResourceRef{
 		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
 		Name:      "default",
 	},
+	{
+		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		Name:      "kube-node-lease",
+	},
+	{
+		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		Name:      "kube-public",
+	},
+	{
+		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		Name:      "kube-system",
+	},
 }
 
 func (c DeleteChange) ApplyStrategy() (ApplyStrategy, error) {
@@ -118,7 +130,7 @@ func (c DeleteOrphanStrategy) Op() ClusterChangeApplyStrategyOp { return deleteS
 func (c DeleteOrphanStrategy) Apply() error {
 	mergePatch := []interface{}{
 		// TODO currently we do not account for when '-a label:foo=bar' used
-		//
+		// Reason: In labeled app labels are not accessible in delete operation now. Without the label info kapp can not apply the changes
 		map[string]interface{}{
 			"op":   "remove",
 			"path": "/metadata/labels/" + jsonPointerEncoder.Replace(appLabelKey),

--- a/pkg/kapp/clusterapply/delete_change.go
+++ b/pkg/kapp/clusterapply/delete_change.go
@@ -33,34 +33,33 @@ type DeleteChange struct {
 	identifiedResources ctlres.IdentifiedResources
 }
 
-type uniqueResourceRef struct {
+type inoperableResourceRef struct {
 	schema.GroupKind
 	Name string
 }
 
-// if any new reource will encountered which kapp can not delete and required to orphaned then resource info will be added here.
-var inoperableResourceList = []uniqueResourceRef{
+// List of resources use the "orphan" delete strategy implicitly as they cannot be deleted by end users
+var inoperableResourceList = []inoperableResourceRef{
 	{
-		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		GroupKind: schema.GroupKind{Group: "", Kind: "Namespace"},
 		Name:      "default",
 	},
 	{
-		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		GroupKind: schema.GroupKind{Group: "", Kind: "Namespace"},
 		Name:      "kube-node-lease",
 	},
 	{
-		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		GroupKind: schema.GroupKind{Group: "", Kind: "Namespace"},
 		Name:      "kube-public",
 	},
 	{
-		GroupKind: schema.GroupKind{Group: "", Kind: "namespace"},
+		GroupKind: schema.GroupKind{Group: "", Kind: "Namespace"},
 		Name:      "kube-system",
 	},
 }
 
 func (c DeleteChange) ApplyStrategy() (ApplyStrategy, error) {
 	res := c.change.ExistingResource()
-
 	strategy := res.Annotations()[deleteStrategyAnnKey]
 
 	if c.isInoperableResource() {
@@ -162,10 +161,8 @@ func descMessage(res ctlres.Resource) []string {
 func (c DeleteChange) isInoperableResource() bool {
 
 	res := c.change.ExistingResource()
-
 	for _, r := range inoperableResourceList {
-		strings.EqualFold(r.Name, res.Name())
-		if strings.EqualFold(r.Name, res.Name()) && strings.EqualFold(r.Kind, res.GroupKind().Kind) && strings.EqualFold(r.Group, res.GroupKind().Group) {
+		if r.Name == res.Name() && r.Kind == res.GroupKind().Kind && r.Group == res.GroupKind().Group {
 			return true
 		}
 	}

--- a/pkg/kapp/clusterapply/delete_change.go
+++ b/pkg/kapp/clusterapply/delete_change.go
@@ -159,10 +159,9 @@ func descMessage(res ctlres.Resource) []string {
 }
 
 func (c DeleteChange) isInoperableResource() bool {
-
 	res := c.change.ExistingResource()
 	for _, r := range inoperableResourceList {
-		if r.Name == res.Name() && r.Kind == res.GroupKind().Kind && r.Group == res.GroupKind().Group {
+		if r == (inoperableResourceRef{Name: res.Name(), GroupKind: res.GroupKind()}) {
 			return true
 		}
 	}

--- a/test/e2e/delete_inoperable_test.go
+++ b/test/e2e/delete_inoperable_test.go
@@ -1,0 +1,75 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeleteInoperable(t *testing.T) {
+
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	yaml1 := `
+--- 
+apiVersion: v1
+kind: Namespace
+metadata: 
+  name: default
+
+`
+
+	name := "test-delete-inoperable"
+	nameAnother := "test-delete-inoperable-another"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+		kapp.Run([]string{"delete", "-a", nameAnother})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy initial", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+
+	logger.Section("delete initial", func() {
+		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+
+	logger.Section("deploy again with same app name", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+
+	logger.Section("deploy without resource to orphan", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--dangerous-allow-empty-list-of-resources"},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader("")})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+
+	logger.Section("deploy another app to adopt", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", nameAnother},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+
+	logger.Section("delete original app", func() {
+		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+
+	logger.Section("delete another app", func() {
+		kapp.RunWithOpts([]string{"delete", "-a", nameAnother}, RunOpts{})
+		NewPresentClusterResource("namespace", "default", env.Namespace, kubectl)
+	})
+}

--- a/test/e2e/delete_inoperable_test.go
+++ b/test/e2e/delete_inoperable_test.go
@@ -21,7 +21,6 @@ apiVersion: v1
 kind: Namespace
 metadata: 
   name: default
-
 `
 
 	name := "test-delete-inoperable"

--- a/test/e2e/delete_inoperable_test.go
+++ b/test/e2e/delete_inoperable_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestDeleteInoperable(t *testing.T) {
-
 	env := BuildEnv(t)
 	logger := Logger{}
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}


### PR DESCRIPTION
**Why this PR and what it is doing**
Issue was:  Inoperable resources like default namespace are not allowed to delete which was throwing error on kapp delete.
Solution:  For all inoperable resources kapp will orphaned the requested resource instead of trying to delete.


TODO:
- [x]  Manual testing for the changes 
- [x] Add e2e test case



NOTE: If you feel there should be more resources in the list please suggest.