### PR TITLE
Support for matching observedGeneration for status.Condition level

### DIFF
--- a/pkg/kapp/config/config.go
+++ b/pkg/kapp/config/config.go
@@ -47,10 +47,11 @@ type WaitRule struct {
 }
 
 type WaitRuleConditionMatcher struct {
-	Type    string
-	Status  string
-	Failure bool
-	Success bool
+	Type                       string
+	Status                     string
+	Failure                    bool
+	Success                    bool
+	SupportsObservedGeneration bool
 }
 
 type RebaseRule struct {

--- a/pkg/kapp/resourcesmisc/custom_waiting_resource.go
+++ b/pkg/kapp/resourcesmisc/custom_waiting_resource.go
@@ -56,13 +56,13 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 	}
 
 	// True if a condition has not observed the latest generation
-	condObsGenMatchWait := false
+	hasConditionWaitingForGeneration := false
 	// Check on failure conditions first
 	for _, condMatcher := range s.waitRule.ConditionMatchers {
 		for _, cond := range obj.Status.Conditions {
 			if cond.Type == condMatcher.Type && cond.Status == condMatcher.Status {
 				if condMatcher.SupportsObservedGeneration && obj.Metadata.Generation != cond.ObservedGeneration {
-					condObsGenMatchWait = true
+					hasConditionWaitingForGeneration = true
 					continue
 				}
 				if condMatcher.Failure {
@@ -79,7 +79,7 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 		for _, cond := range obj.Status.Conditions {
 			if cond.Type == condMatcher.Type && cond.Status == condMatcher.Status {
 				if condMatcher.SupportsObservedGeneration && obj.Metadata.Generation != cond.ObservedGeneration {
-					condObsGenMatchWait = true
+					hasConditionWaitingForGeneration = true
 					continue
 				}
 				if condMatcher.Success {
@@ -91,7 +91,7 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 		}
 	}
 
-	if condObsGenMatchWait {
+	if hasConditionWaitingForGeneration {
 		return DoneApplyState{Done: false, Message: fmt.Sprintf(
 			"Waiting for generation %d to be observed by status condition(s)", obj.Metadata.Generation)}
 	}

--- a/pkg/kapp/resourcesmisc/custom_waiting_resource.go
+++ b/pkg/kapp/resourcesmisc/custom_waiting_resource.go
@@ -58,11 +58,11 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 	// Check on failure conditions first
 	for _, condMatcher := range s.waitRule.ConditionMatchers {
 		for _, cond := range obj.Status.Conditions {
-			if condMatcher.SupportsObservedGeneration && obj.Metadata.Generation != cond.ObservedGeneration {
-				return DoneApplyState{Done: false, Message: fmt.Sprintf(
-					"Waiting for generation %d to be observed at status condition %s level", obj.Metadata.Generation, cond.Type)}
-			}
 			if cond.Type == condMatcher.Type && cond.Status == condMatcher.Status {
+				if condMatcher.SupportsObservedGeneration && obj.Metadata.Generation != cond.ObservedGeneration {
+					return DoneApplyState{Done: false, Message: fmt.Sprintf(
+						"Waiting for generation %d to be observed at status condition %s level", obj.Metadata.Generation, cond.Type)}
+				}
 				if condMatcher.Failure {
 					return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 						"Encountered failure condition %s == %s: %s (message: %s)",
@@ -75,11 +75,11 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 	// If no failure conditions found, check on successful ones
 	for _, condMatcher := range s.waitRule.ConditionMatchers {
 		for _, cond := range obj.Status.Conditions {
-			if condMatcher.SupportsObservedGeneration && obj.Metadata.Generation != cond.ObservedGeneration {
-				return DoneApplyState{Done: false, Message: fmt.Sprintf(
-					"Waiting for generation %d to be observed at status condition %s level", obj.Metadata.Generation, cond.Type)}
-			}
 			if cond.Type == condMatcher.Type && cond.Status == condMatcher.Status {
+				if condMatcher.SupportsObservedGeneration && obj.Metadata.Generation != cond.ObservedGeneration {
+					return DoneApplyState{Done: false, Message: fmt.Sprintf(
+						"Waiting for generation %d to be observed at status condition %s level", obj.Metadata.Generation, cond.Type)}
+				}
 				if condMatcher.Success {
 					return DoneApplyState{Done: true, Successful: true, Message: fmt.Sprintf(
 						"Encountered successful condition %s == %s: %s (message: %s)",

--- a/pkg/kapp/resourcesmisc/custom_waiting_resource.go
+++ b/pkg/kapp/resourcesmisc/custom_waiting_resource.go
@@ -55,7 +55,6 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 			"Waiting for generation %d to be observed", obj.Metadata.Generation)}
 	}
 
-	// True if a condition has not observed the latest generation
 	hasConditionWaitingForGeneration := false
 	// Check on failure conditions first
 	for _, condMatcher := range s.waitRule.ConditionMatchers {


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu/carvel-kapp/issues/435
Solution: support for matching observedGeneration for status.Condition level

TODO

- [x] Manual testing
- [x] Should check for observedGeneration for each status.Condition if  SupportsObservedGeneration=true in waitRule.ConditionMatchers. (tested for cert manager as this condition is not applicable for some specific type resource)


**Reference(tested with CR cert-manager's certificate https://cert-manager.io/docs/usage/certificate/)**
_I have used kapp config while deploying certificate :_
```
apiVersion:` kapp.k14s.io/v1alpha1
kind: Config
waitRules:
- resourceMatchers:
  - apiVersionKindMatcher:
      apiVersion: cert-manager.io/v1
      kind: Certificate
  conditionMatchers:
  - type: Ready
    status: "False"
    success: true
    supportsObservedGeneration: true
  ```
    
In this scenario what kapp will do is, kapp will check if conditionMatchers.supportsObservedGeneration = true then it will match Metadata.Generation with Status.Condition.ObservedGeneration , also check for type =ready and status=false then kapp will say the resource got deployed successfully.
