### PR TITLE
Migrated apps to have suffix when FQ env is unset

### DIFF
--- a/pkg/kapp/app/apps.go
+++ b/pkg/kapp/app/apps.go
@@ -54,7 +54,7 @@ func (a Apps) Find(name string) (App, error) {
 	}
 
 	return NewRecordedApp(name, a.nsName, time.Time{}, a.coreClient,
-		a.identifiedResources, a.appInDiffNsHintMsg, a.logger, nil), nil
+		a.identifiedResources, a.appInDiffNsHintMsg, a.logger), nil
 }
 
 func (a Apps) List(additionalLabels map[string]string) ([]App, error) {
@@ -82,8 +82,12 @@ func (a Apps) list(additionalLabels map[string]string, nsName string) ([]App, er
 	}
 
 	for _, app := range apps.Items {
-		result = append(result, NewRecordedApp(app.Name, app.Namespace, app.ObjectMeta.CreationTimestamp.Time, a.coreClient,
-			a.identifiedResources, a.appInDiffNsHintMsg, a.logger, &app))
+		recordedApp := NewRecordedApp(app.Name, app.Namespace, app.ObjectMeta.CreationTimestamp.Time, a.coreClient,
+			a.identifiedResources, a.appInDiffNsHintMsg, a.logger)
+
+		recordedApp.setMeta(app)
+
+		result = append(result, recordedApp)
 	}
 
 	return result, nil

--- a/pkg/kapp/app/apps.go
+++ b/pkg/kapp/app/apps.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -89,7 +90,7 @@ func (a Apps) list(additionalLabels map[string]string, nsName string) ([]App, er
 		name := app.Name
 		isMigrated := false
 
-		if _, ok := app.Annotations[KappIsConfigmapMigratedAnnotationKey]; ok {
+		if _, ok := app.Annotations[KappIsConfigmapMigratedAnnotationKey]; ok && strings.ToLower(os.Getenv("KAPP_FQ_CONFIGMAP_NAMES")) == "true" {
 			name = strings.TrimSuffix(app.Name, AppSuffix)
 			isMigrated = true
 		}

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -43,21 +43,15 @@ type RecordedApp struct {
 }
 
 func NewRecordedApp(name, nsName string, creationTimestamp time.Time, coreClient kubernetes.Interface,
-	identifiedResources ctlres.IdentifiedResources, appInDiffNsHintMsgFunc func(string) string, logger logger.Logger, app *corev1.ConfigMap) *RecordedApp {
+	identifiedResources ctlres.IdentifiedResources, appInDiffNsHintMsgFunc func(string) string, logger logger.Logger) *RecordedApp {
 
 	recordedApp := &RecordedApp{name, nsName, false, creationTimestamp, coreClient, identifiedResources, appInDiffNsHintMsgFunc,
 		nil, logger.NewPrefixed("RecordedApp")}
 
-	if app == nil {
-		return recordedApp
-	}
-
-	if _, ok := app.Annotations[KappIsConfigmapMigratedAnnotationKey]; ok && recordedApp.isMigrationEnabled() {
+	if recordedApp.isMigrationEnabled() {
+		// If migration is enabled always trim suffix, even if user added it manually (to avoid double migration)
 		recordedApp.name = strings.TrimSuffix(recordedApp.name, AppSuffix)
-		recordedApp.isMigrated = true
 	}
-
-	recordedApp.setMeta(*app)
 
 	return recordedApp
 }

--- a/test/e2e/app_suffix_test.go
+++ b/test/e2e/app_suffix_test.go
@@ -100,21 +100,20 @@ func TestAppSuffix_AppExists_MigrationEnabled(t *testing.T) {
 		NewMissingClusterResource(t, "configmap", newName, env.Namespace, kubectl)
 	})
 
-	logger.Section("name already contains app suffix", func() {
-		existingName := name + app.AppSuffix
-
-		os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "False")
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", existingName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
-		NewPresentClusterResource("configmap", existingName, env.Namespace, kubectl)
-
+	logger.Section("name contains app suffix for migrated app", func() {
 		os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "True")
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", existingName}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		NewPresentClusterResource("configmap", name+app.AppSuffix, env.Namespace, kubectl)
 
-		NewMissingClusterResource(t, "configmap", existingName, env.Namespace, kubectl)
-		c := NewPresentClusterResource("configmap", existingName+app.AppSuffix, env.Namespace, kubectl)
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name + app.AppSuffix}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+		// double migration shouldn't have happened
+		NewMissingClusterResource(t, "configmap", name+app.AppSuffix+app.AppSuffix, env.Namespace, kubectl)
+
+		c := NewPresentClusterResource("configmap", name+app.AppSuffix, env.Namespace, kubectl)
 		require.Contains(t, c.res.Annotations(), app.KappIsConfigmapMigratedAnnotationKey)
 
-		kapp.Run([]string{"delete", "-a", existingName})
+		kapp.Run([]string{"delete", "-a", name})
 	})
 
 	// if a user has disabled the migration on an app that was already migrated

--- a/test/e2e/create_update_delete_test.go
+++ b/test/e2e/create_update_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	uitest "github.com/cppforlife/go-cli-ui/ui/test"
 	"github.com/k14s/kapp/pkg/kapp/app"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	"github.com/stretchr/testify/require"
@@ -197,6 +198,19 @@ data:
 
 		// KAPP_FQ_CONFIGMAP_NAMES=False is not supported - must go from migrated => migrated
 		os.Setenv("KAPP_FQ_CONFIGMAP_NAMES", "False")
+		out := kapp.Run([]string{"ls", "--json"})
+
+		expectedAppsList := []map[string]string{{
+			"last_change_age":        "<replaced>",
+			"last_change_successful": "true",
+			"name":                   prevAppName + app.AppSuffix,
+			"namespaces":             env.Namespace,
+		}}
+
+		resp := uitest.JSONUIFromBytes(t, []byte(out))
+
+		require.Equalf(t, expectedAppsList, replaceLastChangeAge(resp.Tables[0].Rows), "Expected to match")
+
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", appName, "--prev-app", prevAppName},
 			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(yaml2)})
 


### PR DESCRIPTION
- Migrated app names to have suffix when KAPP_FQ_CONFIGMAP_NAMES env variable is unset, just like old versions of kapp would have
- Add constructor for recorded app
- Remove suffix when migration is enabled (this prevents double migration when someone is using fully qualified name even when migration is enabled)

`Current behaviour`
```bash
export KAPP_FQ_CONFIGMAP_NAMES=true

kapp deploy -a my-app -f app.yml --yes

$ kapp ls
Namespace  Name        Namespaces  Lcs   Lca
default    my-app      default     true  7s

$ KAPP_FQ_CONFIGMAP_NAMES=false kapp ls
Namespace  Name        Namespaces  Lcs   Lca
default    my-app      default     true  7s

KAPP_FQ_CONFIGMAP_NAMES=false inspect my-app
kapp: Error: App 'my-app' (namespace: default) does not exist: configmaps "my-app" not found
```

`Expected behaviour from this change`
```bash
export KAPP_FQ_CONFIGMAP_NAMES=true

kapp deploy -a my-app -f app.yml --yes

$ kapp ls
Namespace  Name        Namespaces  Lcs   Lca
default    my-app      default     true  7s

$ KAPP_FQ_CONFIGMAP_NAMES=false kapp ls
Namespace  Name                     Namespaces  Lcs   Lca
default    my-app.apps.k14s.io      default     true  7s
```

Doc [PR](https://github.com/vmware-tanzu/carvel/pull/414)