### PR TITLE
update or noop fallback: allow a rebase rule to turn an update into a noop

### DIFF
--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -205,6 +205,7 @@ func (a *RecordedApp) createOrUpdate(c *corev1.ConfigMap, labels map[string]stri
 			if err != nil {
 				return fmt.Errorf("Updating app: %s", err)
 			}
+
 			return nil
 		}
 

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -205,7 +205,6 @@ func (a *RecordedApp) createOrUpdate(c *corev1.ConfigMap, labels map[string]stri
 			if err != nil {
 				return fmt.Errorf("Updating app: %s", err)
 			}
-
 			return nil
 		}
 

--- a/test/e2e/create_fallback_on_noop_test.go
+++ b/test/e2e/create_fallback_on_noop_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateFallbackOnNoop(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	objNs := env.Namespace + "-create-fallback-on-noop"
+	// TODO: fallback-on-update-or-noop
+	nsYaml := strings.Replace(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: __ns__
+`, "__ns__", objNs, -1)
+	objYaml := strings.Replace(`
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: precious-resource
+  namespace: __ns__
+  annotations:
+    kapp.k14s.io/create-strategy: "fallback-on-noop"
+data: {"refName":"pkg9.test.carvel.dev","releasedAt":null,"version":"0.0.0"}
+`, "__ns__", objNs, -1)
+
+	rebaseRule := `
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+- ytt:
+    overlayContractV1:
+      overlay.yml: |
+        #@ load("@ytt:overlay", "overlay")
+
+        #@overlay/match by=overlay.all
+        ---
+        metadata:
+          #@overlay/match missing_ok=True
+          annotations:
+            #@overlay/match missing_ok=True
+            kapp.k14s.io/noop: ""
+  resourceMatchers:
+  - apiVersionKindMatcher: {apiVersion: v1, kind: ConfigMap}
+`
+
+	name := "test-create-fallback-on-noop"
+	name2 := "test-2"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+		kapp.Run([]string{"delete", "-a", name2})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy initial ns and package", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-y"},
+			RunOpts{AllowError: false, StdinReader: strings.NewReader(nsYaml + objYaml)})
+		assert.NoError(t, err)
+	})
+
+	logger.Section("assert theres a configmap that belongs to the app", func() {
+		out := kapp.Run([]string{"inspect", "-a", name})
+		assert.Contains(t, out, "precious-resource")
+	})
+
+	logger.Section("deploy a second app with noop-strategy annotation", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2,
+			"--existing-non-labeled-resources-check=false", "--dangerous-override-ownership-of-existing-resources", "-y", "--json"},
+			RunOpts{AllowError: false, StdinReader: strings.NewReader(objYaml + rebaseRule)})
+		assert.NoError(t, err)
+	})
+
+	logger.Section("assert the configmap still belongs to the first app", func() {
+		out := kapp.Run([]string{"inspect", "-a", name})
+		assert.Contains(t, out, "precious-resource")
+	})
+
+	logger.Section("assert the configmap doesn't belong to the second app", func() {
+		out := kapp.Run([]string{"inspect", "-a", name2})
+		assert.NotContains(t, out, "precious-resource")
+	})
+}

--- a/test/e2e/create_fallback_on_noop_test.go
+++ b/test/e2e/create_fallback_on_noop_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateFallbackOnNoop(t *testing.T) {
@@ -15,26 +16,16 @@ func TestCreateFallbackOnNoop(t *testing.T) {
 	logger := Logger{}
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
-	objNs := env.Namespace + "-create-fallback-on-noop"
-	nsYaml := strings.Replace(`
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: __ns__
-`, "__ns__", objNs, -1)
-	objYaml := strings.Replace(`
+	objYaml := `
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: precious-resource
-  namespace: __ns__
   annotations:
     kapp.k14s.io/create-strategy: "fallback-on-update-or-noop"
 data: {"importantFact":"true","releasedAt":null}
-`, "__ns__", objNs, -1)
-
+`
 	rebaseRule := `
 ---
 apiVersion: kapp.k14s.io/v1alpha1
@@ -55,9 +46,8 @@ rebaseRules:
   resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: v1, kind: ConfigMap}
 `
-
 	name := "test-create-fallback-on-noop"
-	name2 := "test-2"
+	name2 := "test-create-fallback-on-noop2"
 	cleanUp := func() {
 		kapp.Run([]string{"delete", "-a", name})
 		kapp.Run([]string{"delete", "-a", name2})
@@ -66,22 +56,18 @@ rebaseRules:
 	cleanUp()
 	defer cleanUp()
 
-	logger.Section("deploy initial ns and package", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-y"},
-			RunOpts{AllowError: false, StdinReader: strings.NewReader(nsYaml + objYaml)})
-		assert.NoError(t, err)
-	})
+	logger.Section("deploy initial app and assert it has its precious", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-y"},
+			RunOpts{StdinReader: strings.NewReader(objYaml)})
 
-	logger.Section("assert theres a configmap that belongs to the app", func() {
 		out := kapp.Run([]string{"inspect", "-a", name})
-		assert.Contains(t, out, "precious-resource")
+		require.Contains(t, out, "precious-resource")
 	})
 
 	logger.Section("deploy a second app with noop-strategy annotation", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2,
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2,
 			"--existing-non-labeled-resources-check=false", "--dangerous-override-ownership-of-existing-resources", "-y", "--json"},
-			RunOpts{AllowError: false, StdinReader: strings.NewReader(objYaml + rebaseRule)})
-		assert.NoError(t, err)
+			RunOpts{StdinReader: strings.NewReader(objYaml + rebaseRule)})
 	})
 
 	logger.Section("assert the configmap still belongs to the first app, not the second", func() {
@@ -92,10 +78,9 @@ rebaseRules:
 	})
 
 	logger.Section("redeploy the second app without the rebase rule and it steals ownership of the configmap", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2,
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2,
 			"--existing-non-labeled-resources-check=false", "--dangerous-override-ownership-of-existing-resources", "-y", "--json"},
-			RunOpts{AllowError: false, StdinReader: strings.NewReader(objYaml)})
-		assert.NoError(t, err)
+			RunOpts{StdinReader: strings.NewReader(objYaml)})
 
 		out := kapp.Run([]string{"inspect", "-a", name2})
 		assert.Contains(t, out, "precious-resource")


### PR DESCRIPTION
Dear kapp team,
I heard you-all are big on acceptance criteria, so here's an attempt:

kapp-controller needs an "upsert or walk away and do nothing" mechanism:
- the initial existence checks are too expensive in some backends (especially ones that rhyme with "crewgle crowd crengine") so we have to be able to pass `--existing-non-labeled-resources-check=false`
- because we're not checking for existence, sometimes the create is going to be an update of an existing object (so the operation we really want to perform is an upsert, which is basically what the create-strategy: fallback annotation already provides.)
- also under _certain conditions_ we want to ensure that:
  - the upsert doesn't change the underlying resource
  - the upsert doesn't change the owner
  - i.e. we want the upsert to turn into a noop, through conditionals checked in a rebaserule. 
  
  this PR accomplishes those goals by adding a new fallback-on-update-or-noop option to the create-strategy annotation.

  I don't think the code is particularly pretty and am happy to take suggestions on how else to organize it / pass information. Also happy if anyone sees a different path for accomplishing this goal.