### PR TITLE
Add recalculated diff to conflicting update error

### DIFF
--- a/pkg/kapp/clusterapply/add_or_update_change.go
+++ b/pkg/kapp/clusterapply/add_or_update_change.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	ctlconf "github.com/k14s/kapp/pkg/kapp/config"
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	"github.com/k14s/kapp/pkg/kapp/util"
@@ -35,6 +36,7 @@ type AddOrUpdateChange struct {
 	changeFactory       ctldiff.ChangeFactory
 	changeSetFactory    ctldiff.ChangeSetFactory
 	opts                AddOrUpdateChangeOpts
+	diffMaskRules       []ctlconf.DiffMaskRule
 }
 
 func (c AddOrUpdateChange) ApplyStrategy() (ApplyStrategy, error) {
@@ -143,7 +145,13 @@ func (c AddOrUpdateChange) tryToResolveUpdateConflict(
 			return fmt.Errorf("Expected recalculated change to be an update")
 		}
 		if recalcChanges[0].OpsDiff().MinimalMD5() != c.change.OpsDiff().MinimalMD5() {
-			return fmt.Errorf(errMsgPrefix+"(approved diff no longer matches): %s", origErr)
+			errMsg := fmt.Sprintf(errMsgPrefix+"(approved diff no longer matches): %s", origErr)
+
+			textDiff, err := recalcChanges[0].ConfigurableTextDiff().Masked(c.diffMaskRules)
+			if err != nil {
+				return fmt.Errorf(errMsg)
+			}
+			return fmt.Errorf("%s: Recalculated diff:\n%s", errMsg, textDiff.MinimalString())
 		}
 
 		updatedRes, err := c.identifiedResources.Update(recalcChanges[0].NewResource())

--- a/pkg/kapp/clusterapply/cluster_change.go
+++ b/pkg/kapp/clusterapply/cluster_change.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	uierrs "github.com/cppforlife/go-cli-ui/errors"
+	ctlconf "github.com/k14s/kapp/pkg/kapp/config"
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	ctlresm "github.com/k14s/kapp/pkg/kapp/resourcesmisc"
@@ -65,6 +66,8 @@ type ClusterChange struct {
 	ui                  UI
 
 	markedNeedsWaiting bool
+
+	diffMaskRules []ctlconf.DiffMaskRule
 }
 
 var _ ChangeView = &ClusterChange{}
@@ -73,10 +76,11 @@ func NewClusterChange(change ctldiff.Change, opts ClusterChangeOpts,
 	identifiedResources ctlres.IdentifiedResources,
 	changeFactory ctldiff.ChangeFactory,
 	changeSetFactory ctldiff.ChangeSetFactory,
-	convergedResFactory ConvergedResourceFactory, ui UI) *ClusterChange {
+	convergedResFactory ConvergedResourceFactory, ui UI,
+	diffMaskRules []ctlconf.DiffMaskRule) *ClusterChange {
 
 	return &ClusterChange{change, opts, identifiedResources,
-		changeFactory, changeSetFactory, convergedResFactory, ui, false}
+		changeFactory, changeSetFactory, convergedResFactory, ui, false, diffMaskRules}
 }
 
 func (c *ClusterChange) ApplyOp() ClusterChangeApplyOp {
@@ -202,7 +206,7 @@ func (c *ClusterChange) applyStrategy() (ApplyStrategy, error) {
 	case ClusterChangeApplyOpAdd, ClusterChangeApplyOpUpdate:
 		return AddOrUpdateChange{
 			c.change, c.identifiedResources, c.changeFactory,
-			c.changeSetFactory, c.opts.AddOrUpdateChangeOpts}.ApplyStrategy()
+			c.changeSetFactory, c.opts.AddOrUpdateChangeOpts, c.diffMaskRules}.ApplyStrategy()
 
 	case ClusterChangeApplyOpDelete:
 		return DeleteChange{c.change, c.identifiedResources}.ApplyStrategy()

--- a/pkg/kapp/clusterapply/cluster_change_factory.go
+++ b/pkg/kapp/clusterapply/cluster_change_factory.go
@@ -4,6 +4,7 @@
 package clusterapply
 
 import (
+	ctlconf "github.com/k14s/kapp/pkg/kapp/config"
 	ctldiff "github.com/k14s/kapp/pkg/kapp/diff"
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 )
@@ -15,6 +16,7 @@ type ClusterChangeFactory struct {
 	changeSetFactory    ctldiff.ChangeSetFactory
 	convergedResFactory ConvergedResourceFactory
 	ui                  UI
+	diffMaskRules       []ctlconf.DiffMaskRule
 }
 
 func NewClusterChangeFactory(
@@ -22,13 +24,14 @@ func NewClusterChangeFactory(
 	identifiedResources ctlres.IdentifiedResources,
 	changeFactory ctldiff.ChangeFactory,
 	changeSetFactory ctldiff.ChangeSetFactory,
-	convergedResFactory ConvergedResourceFactory, ui UI,
+	convergedResFactory ConvergedResourceFactory,
+	ui UI, diffMaskRules []ctlconf.DiffMaskRule,
 ) ClusterChangeFactory {
 	return ClusterChangeFactory{opts, identifiedResources,
-		changeFactory, changeSetFactory, convergedResFactory, ui}
+		changeFactory, changeSetFactory, convergedResFactory, ui, diffMaskRules}
 }
 
 func (f ClusterChangeFactory) NewClusterChange(change ctldiff.Change) *ClusterChange {
 	return NewClusterChange(change, f.opts, f.identifiedResources,
-		f.changeFactory, f.changeSetFactory, f.convergedResFactory, f.ui)
+		f.changeFactory, f.changeSetFactory, f.convergedResFactory, f.ui, f.diffMaskRules)
 }

--- a/pkg/kapp/cmd/app/delete.go
+++ b/pkg/kapp/cmd/app/delete.go
@@ -218,7 +218,7 @@ func (o *DeleteOptions) calculateAndPresentChanges(existingResources []ctlres.Re
 
 			clusterChangeFactory := ctlcap.NewClusterChangeFactory(
 				o.ApplyFlags.ClusterChangeOpts, supportObjs.IdentifiedResources,
-				changeFactory, changeSetFactory, convergedResFactory, msgsUI)
+				changeFactory, changeSetFactory, convergedResFactory, msgsUI, conf.DiffMaskRules())
 
 			clusterChangeSet = ctlcap.NewClusterChangeSet(
 				appliedChanges, o.ApplyFlags.ClusterChangeSetOpts, clusterChangeFactory,

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -406,7 +406,7 @@ func (o *DeployOptions) calculateAndPresentChanges(existingResources,
 
 		clusterChangeFactory := ctlcap.NewClusterChangeFactory(
 			o.ApplyFlags.ClusterChangeOpts, supportObjs.IdentifiedResources,
-			changeFactory, changeSetFactory, convergedResFactory, msgsUI)
+			changeFactory, changeSetFactory, convergedResFactory, msgsUI, conf.DiffMaskRules())
 
 		clusterChangeSet = ctlcap.NewClusterChangeSet(
 			changes, o.ApplyFlags.ClusterChangeSetOpts, clusterChangeFactory,

--- a/test/e2e/update_retry_on_conflict_test.go
+++ b/test/e2e/update_retry_on_conflict_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -191,6 +192,13 @@ spec:
 
 		require.Contains(t, err.Error(), "please apply your changes to the latest version and try again (reason: Conflict)",
 			"Expected error to include k8s reason")
+
+		recalculatedDiff := `Recalculated diff:
+ <replaced> -   - port: 6380
+ <replaced> +   - port: 6381
+ <replaced> -     changed: label`
+
+		require.Contains(t, replaceDiffLineNumber(err.Error()), recalculatedDiff, "Expected error to include recalculated diff")
 	})
 }
 
@@ -327,4 +335,8 @@ func newTmpFile(content string, t *testing.T) *os.File {
 	require.NoError(t, err)
 
 	return file
+}
+
+func replaceDiffLineNumber(result string) string {
+	return regexp.MustCompile("[0-9]+, [0-9]+").ReplaceAllString(result, "<replaced>")
 }


### PR DESCRIPTION
Add masked recalculated diff to conflicting update error message when there's a mismatch in the original diff and new diff.

Sample error message
```bash
kapp: Error: Applying update secret/mysecret (v1) namespace: default:
  Failed to update due to resource conflict (approved diff no longer matches):
    Updating resource secret/mysecret (v1) namespace: default:
      API server says:
        Operation cannot be fulfilled on secrets "mysecret": the object has been modified; please apply your changes to the latest version and try again (reason: Conflict):
          Recalculated diff:
  3,  3 -   password2: <-- value not shown (#1)
  4,  3 +   user: <-- value not shown (#2)
```