### PR TITLE
Use noop for previous versions of a resource

### DIFF
--- a/pkg/kapp/diff/change_precalculated.go
+++ b/pkg/kapp/diff/change_precalculated.go
@@ -20,7 +20,9 @@ type ChangePrecalculated struct {
 
 var _ Change = &ChangePrecalculated{}
 
-func NewChangePrecalculated(existingRes, newRes, appliedRes ctlres.Resource) *ChangePrecalculated {
+func NewChangePrecalculated(existingRes, newRes, appliedRes ctlres.Resource,
+	op ChangeOp, configurableTextDiff *ConfigurableTextDiff, opsDiff OpsDiff) *ChangePrecalculated {
+
 	if existingRes == nil && newRes == nil {
 		panic("Expected either existingRes or newRes be non-nil")
 	}
@@ -35,7 +37,8 @@ func NewChangePrecalculated(existingRes, newRes, appliedRes ctlres.Resource) *Ch
 		appliedRes = appliedRes.DeepCopy()
 	}
 
-	return &ChangePrecalculated{existingRes: existingRes, newRes: newRes, appliedRes: appliedRes}
+	return &ChangePrecalculated{existingRes: existingRes, newRes: newRes, appliedRes: appliedRes,
+		op: op, configurableTextDiff: configurableTextDiff, opsDiff: opsDiff}
 }
 
 func (d *ChangePrecalculated) NewOrExistingResource() ctlres.Resource {

--- a/pkg/kapp/diff/change_set_with_versioned_rs.go
+++ b/pkg/kapp/diff/change_set_with_versioned_rs.go
@@ -175,12 +175,7 @@ func (d ChangeSetWithVersionedRs) newAddChangeFromUpdateChange(
 	newRes ctlres.Resource, updateChange Change) Change {
 
 	// Use update's diffs but create a change for new resource
-	addChange := NewChangePrecalculated(nil, newRes, newRes)
-	// TODO private field access
-	addChange.op = ChangeOpAdd
-	addChange.configurableTextDiff = updateChange.ConfigurableTextDiff()
-	addChange.opsDiff = updateChange.OpsDiff()
-	return addChange
+	return NewChangePrecalculated(nil, newRes, newRes, ChangeOpAdd, updateChange.ConfigurableTextDiff(), updateChange.OpsDiff())
 }
 
 func (d ChangeSetWithVersionedRs) noopAndDeleteChanges(
@@ -223,19 +218,11 @@ func (d ChangeSetWithVersionedRs) noopAndDeleteChanges(
 }
 
 func (d ChangeSetWithVersionedRs) newKeepChange(existingRes ctlres.Resource) Change {
-	// Use update's diffs but create a change for new resource
-	addChange := NewChangePrecalculated(existingRes, nil, nil)
-	// TODO private field access
-	addChange.op = ChangeOpKeep
-	return addChange
+	return NewChangePrecalculated(existingRes, nil, nil, ChangeOpKeep, NewConfigurableTextDiff(existingRes, nil, true), OpsDiff{})
 }
 
 func (d ChangeSetWithVersionedRs) newNoopChange(existingRes ctlres.Resource) Change {
-	// Use update's diffs but create a change for new resource
-	addChange := NewChangePrecalculated(existingRes, nil, nil)
-	// TODO private field access
-	addChange.op = ChangeOpNoop
-	return addChange
+	return NewChangePrecalculated(existingRes, nil, nil, ChangeOpNoop, nil, OpsDiff{})
 }
 
 func (ChangeSetWithVersionedRs) numOfResourcesToKeep(res ctlres.Resource) (int, error) {

--- a/test/e2e/annotations_test.go
+++ b/test/e2e/annotations_test.go
@@ -550,8 +550,8 @@ spec:
 			"Wait to: 1 reconcile, 0 delete, 0 noop", out)
 	})
 
-	logger.Section("deploy with no changes", func() {
-		out, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
+	logger.Section("deploy with no changes and use --diff-changes", func() {
+		out, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-c", "--json"},
 			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(failYaml)})
 
 		require.Error(t, err, "Expected to receive an error")

--- a/test/e2e/annotations_test.go
+++ b/test/e2e/annotations_test.go
@@ -473,3 +473,126 @@ data:
 			"Wait to: 1 reconcile, 1 delete, 0 noop", kappOut)
 	})
 }
+
+func TestVersionedAnnotation_WithFailedPreviousVersions(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	failYaml := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job
+  annotations:
+    kapp.k14s.io/versioned: ""
+spec:
+  template:
+    metadata:
+      name: my-job
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: my-job
+          image: alpine:3.15.0
+          command: [ "sh", "-c", "exit 1" ]
+  backoffLimit: 0
+`
+
+	successYaml := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job
+  annotations:
+    kapp.k14s.io/versioned: ""
+spec:
+  template:
+    metadata:
+      name: my-job
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: my-job
+          image: alpine:3.15.0
+          command: [ "sh", "-c", "exit 0" ]
+  backoffLimit: 0
+`
+
+	name := "test-ver-ann-with-failed-prev-ver"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy ver-1 of job which is expected to fail", func() {
+		out, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
+			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(failYaml)})
+
+		require.Error(t, err, "Expected to receive an error")
+
+		resp := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutput := []map[string]string{{
+			"kind":            "Job",
+			"name":            "my-job-ver-1",
+			"namespace":       env.Namespace,
+			"op":              "create",
+			"op_strategy":     "",
+			"reconcile_info":  "",
+			"reconcile_state": "",
+			"wait_to":         "reconcile",
+		}}
+
+		validateChanges(t, resp.Tables, expectedOutput, "Op:      1 create, 0 delete, 0 update, 0 noop, 0 exists",
+			"Wait to: 1 reconcile, 0 delete, 0 noop", out)
+	})
+
+	logger.Section("deploy with no changes", func() {
+		out, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
+			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(failYaml)})
+
+		require.Error(t, err, "Expected to receive an error")
+
+		resp := uitest.JSONUIFromBytes(t, []byte(out))
+
+		// if no changes are made, then wait for the existing version to reconcile (as it failed previously)
+		expectedOutput := []map[string]string{{
+			"kind":            "Job",
+			"name":            "my-job-ver-1",
+			"namespace":       env.Namespace,
+			"op":              "",
+			"op_strategy":     "",
+			"reconcile_info":  "Failed with reason\nBackoffLimitExceeded: Job has\nreached the specified backoff limit",
+			"reconcile_state": "fail",
+			"wait_to":         "reconcile",
+		}}
+
+		validateChanges(t, resp.Tables, expectedOutput, "Op:      0 create, 0 delete, 0 update, 1 noop, 0 exists",
+			"Wait to: 1 reconcile, 0 delete, 0 noop", out)
+	})
+
+	logger.Section("deploy new version with a change", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(successYaml)})
+
+		resp := uitest.JSONUIFromBytes(t, []byte(out))
+
+		// if a change is made, i.e a new version is created, then kapp should ignore previous failed versions
+		expectedOutput := []map[string]string{{
+			"kind":            "Job",
+			"name":            "my-job-ver-2",
+			"namespace":       env.Namespace,
+			"op":              "create",
+			"op_strategy":     "",
+			"reconcile_info":  "",
+			"reconcile_state": "",
+			"wait_to":         "reconcile",
+		}}
+
+		validateChanges(t, resp.Tables, expectedOutput, "Op:      1 create, 0 delete, 0 update, 0 noop, 0 exists",
+			"Wait to: 1 reconcile, 0 delete, 0 noop", out)
+	})
+}


### PR DESCRIPTION
Use noop for previous versions of a resource and use keep for the latest existing version if there are no changes (Fixes #461)

`Scenarios`
Consider an app that contains a versioned `Job` and has some existing versions on the cluster.
```
Namespace           Name                   Kind       Owner    Rs    Ri                                   Age  
versioned-job-test  my-job-ver-1           Job        kapp     ok    Completed                            17s  
^                   my-job-ver-1--1-5zrjw  Pod        cluster  ok    -                                    17s  
^                   my-job-ver-2           Job        kapp     fail  Failed with reason                   8s  
                                                                     BackoffLimitExceeded: Job has          
                                                                     reached the specified backoff limit
```
Now if we make some changes to the Job and deploy it again, kapp should use `noop` for the previous versions, (i.e. `ver-1` and `ver-2`) and if we don't make any change to the Job, then kapp should use `keep` for `ver-2` and `noop` for `ver-1`.

If we remove the `versioned` annotation, then the behaviour should remain the same (delete all the existing versions and create a new non versioned job)

Usage of `versioned-keep-original` should remain the same.

---

Add configurableTextDiff to existing versions of a resource when op is ChangeOpKeep (Fixes #491 )
- Refactor the constructor NewChangePrecalculated to accept ChangeOp, ConfigurableTextDiff and OpsDiff