### PR TITLE
Always trim ConfigMap suffix

### DIFF
--- a/pkg/kapp/app/apps.go
+++ b/pkg/kapp/app/apps.go
@@ -17,11 +17,8 @@ import (
 )
 
 const (
-	KappIsAppLabelKey                      = "kapp.k14s.io/is-app"
-	kappIsAppLabelValue                    = ""
-	KappIsConfigmapMigratedAnnotationKey   = "kapp.k14s.io/is-configmap-migrated"
-	KappIsConfigmapMigratedAnnotationValue = ""
-	AppSuffix                              = ".apps.k14s.io"
+	KappIsAppLabelKey   = "kapp.k14s.io/is-app"
+	kappIsAppLabelValue = ""
 )
 
 type Apps struct {
@@ -56,9 +53,7 @@ func (a Apps) Find(name string) (App, error) {
 		return nil, fmt.Errorf("Expected non-empty namespace")
 	}
 
-	return &RecordedApp{name, name + AppSuffix, a.nsName, false, time.Time{}, a.coreClient,
-		a.identifiedResources, a.appInDiffNsHintMsg, nil,
-		a.logger.NewPrefixed("RecordedApp")}, nil
+	return NewRecordedApp(name, a.nsName, time.Time{}, a.coreClient, a.identifiedResources, a.appInDiffNsHintMsg, a.logger), nil
 }
 
 func (a Apps) List(additionalLabels map[string]string) ([]App, error) {
@@ -86,17 +81,8 @@ func (a Apps) list(additionalLabels map[string]string, nsName string) ([]App, er
 	}
 
 	for _, app := range apps.Items {
-		name := app.Name
-		isMigrated := false
-
-		if _, ok := app.Annotations[KappIsConfigmapMigratedAnnotationKey]; ok {
-			name = strings.TrimSuffix(app.Name, AppSuffix)
-			isMigrated = true
-		}
-
-		recordedApp := &RecordedApp{name, name + AppSuffix, app.Namespace, isMigrated, app.ObjectMeta.CreationTimestamp.Time, a.coreClient,
-			a.identifiedResources, a.appInDiffNsHintMsg, nil,
-			a.logger.NewPrefixed("RecordedApp")}
+		recordedApp := NewRecordedApp(app.Name, app.Namespace, app.ObjectMeta.CreationTimestamp.Time, a.coreClient,
+			a.identifiedResources, a.appInDiffNsHintMsg, a.logger)
 
 		recordedApp.setMeta(app)
 


### PR DESCRIPTION
Always trim suffix to prevent double migration
- Add constructor for RecordedApp
- Replace fqName (value) with fqName() method

```bash
export KAPP_FQ_CONFIGMAP_NAMES=true

kapp deploy -a my-app -f app.yml --yes

$ kapp ls
Namespace  Name        Namespaces  Lcs   Lca
default    my-app      default     true  7s


$ kapp inspect -a foo.apps.k14s.io
...
Resources in app 'foo'
...
Succeeded


$ KAPP_FQ_CONFIGMAP_NAMES=false kapp inspect -a foo.apps.k14s.io
...
Resources in app 'foo'
...
Succeeded
```