### PR TITLE
display pod logs respecting the value provided in kapp.k14s.io/deploy-log annotation

### DIFF
--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -268,7 +268,8 @@ func (o *DeployOptions) newAndUsedGKs(newGKs []schema.GroupKind, app ctlapp.App)
 		Kind: "Pod",
 	}
 
-	if _, exists := gksByGK[podGK]; !exists {
+	// adding Pod in GKs to get existing Pod resources (#460)
+	if _, exists := gksByGK[podGK]; !exists && o.DeployFlags.Logs {
 		uniqGKs = append(uniqGKs, podGK)
 	}
 

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -144,6 +144,10 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
+	if o.DeployFlags.Logs {
+		usedGKs = append(usedGKs, schema.GroupKind{Kind: "Pod"})
+	}
+
 	existingResources, existingPodRs, err := o.existingResources(
 		newResources, labeledResources, resourceFilter, supportObjs.Apps, usedGKs)
 	if err != nil {

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -144,10 +144,6 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
-	if o.DeployFlags.Logs {
-		usedGKs = append(usedGKs, schema.GroupKind{Kind: "Pod"})
-	}
-
 	existingResources, existingPodRs, err := o.existingResources(
 		newResources, labeledResources, resourceFilter, supportObjs.Apps, usedGKs)
 	if err != nil {
@@ -266,6 +262,14 @@ func (o *DeployOptions) newAndUsedGKs(newGKs []schema.GroupKind, app ctlapp.App)
 			gksByGK[gk] = struct{}{}
 			uniqGKs = append(uniqGKs, gk)
 		}
+	}
+
+	podGK := schema.GroupKind{
+		Kind: "Pod",
+	}
+
+	if _, exists := gksByGK[podGK]; !exists {
+		uniqGKs = append(uniqGKs, podGK)
 	}
 
 	return uniqGKs, nil

--- a/test/e2e/cluster_resource.go
+++ b/test/e2e/cluster_resource.go
@@ -22,6 +22,14 @@ type ClusterResource struct {
 	res ctlres.Resource
 }
 
+func GetClusterResourcesByKind(kind, ns string, kubectl Kubectl) ([]ctlres.Resource, error) {
+	out, err := kubectl.RunWithOpts([]string{"get", kind, "-n", ns, "-o", "yaml"}, RunOpts{AllowError: true})
+	if err != nil {
+		return nil, err
+	}
+	return ctlres.NewResourcesFromBytes([]byte(out))
+}
+
 func NewPresentClusterResource(kind, name, ns string, kubectl Kubectl) ClusterResource {
 	// Since -oyaml output is different between different kubectl versions
 	// due to inclusion/exclusion of managed fields, lets try to

--- a/test/e2e/cluster_resource.go
+++ b/test/e2e/cluster_resource.go
@@ -22,14 +22,6 @@ type ClusterResource struct {
 	res ctlres.Resource
 }
 
-func GetClusterResourcesByKind(kind, ns string, kubectl Kubectl) ([]ctlres.Resource, error) {
-	out, err := kubectl.RunWithOpts([]string{"get", kind, "-n", ns, "-o", "yaml"}, RunOpts{AllowError: true})
-	if err != nil {
-		return nil, err
-	}
-	return ctlres.NewResourcesFromBytes([]byte(out))
-}
-
 func NewPresentClusterResource(kind, name, ns string, kubectl Kubectl) ClusterResource {
 	// Since -oyaml output is different between different kubectl versions
 	// due to inclusion/exclusion of managed fields, lets try to

--- a/test/e2e/pod_log_test.go
+++ b/test/e2e/pod_log_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/pod_log_test.go
+++ b/test/e2e/pod_log_test.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodLogs(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	yaml := `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-app2
+spec:
+  replicas: %d
+  selector:
+    matchLabels:
+      simple-app2: ""
+  template:
+    metadata:
+      labels:
+        simple-app2: ""
+      annotations:
+        kapp.k14s.io/deploy-logs: %s
+    spec:
+      containers:
+        - name: demo-container
+          image: debian
+          command: ["bash","-c","for i in {1..10}; do echo $i -n 'Carvel\n'; sleep 1;  done"]
+`
+
+	name := "test-pod-logs"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	var existingPodLog string
+
+	logger.Section("Should only show log for new Pod with replicas 1", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true,
+			StdinReader: strings.NewReader(fmt.Sprintf(yaml, 1, ""))})
+		resources, _ := GetClusterResourcesByKind("Pod", "default", kubectl)
+		if len(resources) > 0 {
+			existingPodLog = fmt.Sprintf("logs | %s > demo-container | ", resources[0].Name())
+			require.Contains(t, out, existingPodLog, "Expected to show log for the first Pod")
+		}
+	})
+
+	logger.Section("Should not show log for existing Pod when replicas changed to 2", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, 2, "for-new"))})
+		if existingPodLog != "" {
+			require.NotContains(t, out, existingPodLog, "Should not contain log for the existing Pod")
+		}
+	})
+}

--- a/test/e2e/pod_log_test.go
+++ b/test/e2e/pod_log_test.go
@@ -18,27 +18,27 @@ func TestPodLogs(t *testing.T) {
 	kubectl := Kubectl{t, env.Namespace, logger}
 
 	yaml := `
----
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: simple-app2
+  name: simple-app
 spec:
-  replicas: %d
   selector:
     matchLabels:
-      simple-app2: ""
+      simple-app: ""
+  serviceName: simple-app
+  replicas: %d
   template:
     metadata:
       labels:
-        simple-app2: ""
+        simple-app: ""
       annotations:
         kapp.k14s.io/deploy-logs: %s
     spec:
       containers:
         - name: demo-container
           image: debian
-          command: ["bash","-c","for i in {1..10}; do echo $i -n 'Carvel\n'; sleep 1;  done"]
+          command: ["bash","-c","for i in {1..20}; do echo $i -n 'Carvel\n'; sleep 1;  done"]
 `
 
 	name := "test-pod-logs"
@@ -49,22 +49,24 @@ spec:
 	cleanUp()
 	defer cleanUp()
 
-	var existingPodLog string
-
-	logger.Section("Should only show log for new Pod with replicas 1", func() {
+	logger.Section("Show logs for new Pods only when annotation value is default", func() {
 		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true,
 			StdinReader: strings.NewReader(fmt.Sprintf(yaml, 1, ""))})
-		resources, _ := GetClusterResourcesByKind("Pod", "default", kubectl)
-		if len(resources) > 0 {
-			existingPodLog = fmt.Sprintf("logs | %s > demo-container | ", resources[0].Name())
-			require.Contains(t, out, existingPodLog, "Expected to show log for the first Pod")
-		}
+		NewPresentClusterResource("Pod", "simple-app-0", "default", kubectl)
+		out, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, 2, ""))})
+		NewPresentClusterResource("Pod", "simple-app-1", "default", kubectl)
+		require.NotContains(t, out, "logs | simple-app-0 > demo-container | ", "Should not contain log for the existing Pod")
+		require.Contains(t, out, "logs | simple-app-1 > demo-container | ", "Should contain log for the new Pod")
 	})
 
-	logger.Section("Should not show log for existing Pod when replicas changed to 2", func() {
-		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, 2, "for-new"))})
-		if existingPodLog != "" {
-			require.NotContains(t, out, existingPodLog, "Should not contain log for the existing Pod")
-		}
+	cleanUp()
+
+	logger.Section("Show logs only for existing Pods with for-existing annotation value", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, 1, "for-existing"))})
+		NewPresentClusterResource("Pod", "simple-app-0", "default", kubectl)
+		out, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, 2, "for-existing"))})
+		NewPresentClusterResource("Pod", "simple-app-1", "default", kubectl)
+		require.Contains(t, out, "logs | simple-app-0 > demo-container | ", "Should contain log for the existing Pod")
+		require.NotContains(t, out, "logs | simple-app-1 > demo-container | ", "Should not contain log for the new Pod")
 	})
 }


### PR DESCRIPTION
Issue - #460 

`kapp.k14s.io/deploy-log`  with the default value of "" and with the specified valued "for-new" `kapp` should omit logs for existing pods and only show logs for new pods.