### PR TITLE
Add support for unblocking waiting changes in wait rule conditions

### DIFF
--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -102,6 +102,10 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 			case !state.Done:
 				newInProgressChanges = append(newInProgressChanges, change)
 
+				if state.UnblockBlockedChanges {
+					doneChanges = append(doneChanges, change)
+				}
+
 			case state.Done && !state.Successful:
 				msg := ""
 				if len(state.Message) > 0 {

--- a/pkg/kapp/clusterapply/waiting_changes.go
+++ b/pkg/kapp/clusterapply/waiting_changes.go
@@ -102,7 +102,7 @@ func (c *WaitingChanges) WaitForAny() ([]WaitingChange, error) {
 			case !state.Done:
 				newInProgressChanges = append(newInProgressChanges, change)
 
-				if state.UnblockBlockedChanges {
+				if state.UnblockChanges {
 					doneChanges = append(doneChanges, change)
 				}
 

--- a/pkg/kapp/config/config.go
+++ b/pkg/kapp/config/config.go
@@ -53,6 +53,7 @@ type WaitRuleConditionMatcher struct {
 	Failure                    bool
 	Success                    bool
 	SupportsObservedGeneration bool
+	SupportsUnblockingChanges  bool
 }
 
 type WaitRuleYtt struct {

--- a/pkg/kapp/config/config.go
+++ b/pkg/kapp/config/config.go
@@ -53,7 +53,7 @@ type WaitRuleConditionMatcher struct {
 	Failure                    bool
 	Success                    bool
 	SupportsObservedGeneration bool
-	SupportsUnblockingChanges  bool
+	UnblockChanges             bool
 }
 
 type WaitRuleYtt struct {

--- a/pkg/kapp/resourcesmisc/custom_waiting_resource.go
+++ b/pkg/kapp/resourcesmisc/custom_waiting_resource.go
@@ -65,8 +65,12 @@ func (s CustomWaitingResource) IsDoneApplying() DoneApplyState {
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Error: Applying ytt wait rule: %s", err.Error())}
 		}
+		message := configObj.Message
+		if configObj.UnblockBlockedChanges {
+			message = fmt.Sprintf("Allowing blocked changes to proceed: %s", configObj.Message)
+		}
 		return DoneApplyState{Done: configObj.Done, Successful: configObj.Successful,
-			Message: configObj.Message}
+			UnblockBlockedChanges: configObj.UnblockBlockedChanges, Message: message}
 	}
 
 	hasConditionWaitingForGeneration := false

--- a/pkg/kapp/resourcesmisc/done_apply_state.go
+++ b/pkg/kapp/resourcesmisc/done_apply_state.go
@@ -7,6 +7,8 @@ type DoneApplyState struct {
 	Done       bool   `json:"done"`
 	Successful bool   `json:"successful"`
 	Message    string `json:"message"`
+
+	UnblockBlockedChanges bool
 }
 
 func (s DoneApplyState) TerminallyFailed() bool {

--- a/pkg/kapp/resourcesmisc/done_apply_state.go
+++ b/pkg/kapp/resourcesmisc/done_apply_state.go
@@ -8,7 +8,7 @@ type DoneApplyState struct {
 	Successful bool   `json:"successful"`
 	Message    string `json:"message"`
 
-	UnblockBlockedChanges bool
+	UnblockBlockedChanges bool `json:"unblockBlockedChanges"`
 }
 
 func (s DoneApplyState) TerminallyFailed() bool {

--- a/pkg/kapp/resourcesmisc/done_apply_state.go
+++ b/pkg/kapp/resourcesmisc/done_apply_state.go
@@ -8,7 +8,7 @@ type DoneApplyState struct {
 	Successful bool   `json:"successful"`
 	Message    string `json:"message"`
 
-	UnblockBlockedChanges bool `json:"unblockBlockedChanges"`
+	UnblockChanges bool `json:"unblockChanges"`
 }
 
 func (s DoneApplyState) TerminallyFailed() bool {

--- a/pkg/kapp/resourcesmisc/wait_rule_contract_v1.go
+++ b/pkg/kapp/resourcesmisc/wait_rule_contract_v1.go
@@ -26,6 +26,8 @@ type WaitRuleContractV1ResultDetails struct {
 	Done       bool   `json:"done"`
 	Successful bool   `json:"successful"`
 	Message    string `json:"message"`
+
+	UnblockBlockedChanges bool `json:"unblockBlockedChanges"`
 }
 
 func (t WaitRuleContractV1) Apply(res ctlres.Resource) (*WaitRuleContractV1ResultDetails, error) {

--- a/pkg/kapp/resourcesmisc/wait_rule_contract_v1.go
+++ b/pkg/kapp/resourcesmisc/wait_rule_contract_v1.go
@@ -27,7 +27,7 @@ type WaitRuleContractV1ResultDetails struct {
 	Successful bool   `json:"successful"`
 	Message    string `json:"message"`
 
-	UnblockBlockedChanges bool `json:"unblockBlockedChanges"`
+	UnblockChanges bool `json:"unblockChanges"`
 }
 
 func (t WaitRuleContractV1) Apply(res ctlres.Resource) (*WaitRuleContractV1ResultDetails, error) {

--- a/test/e2e/cluster_resource.go
+++ b/test/e2e/cluster_resource.go
@@ -63,6 +63,17 @@ func PatchClusterResource(kind, name, ns, patch string, kubectl Kubectl) {
 	kubectl.Run([]string{"patch", kind, name, "--type=json", "--patch", patch, "-n", ns})
 }
 
+func ClusterResourceExists(kind, name string, kubectl Kubectl) (bool, error) {
+	_, err := kubectl.RunWithOpts([]string{"get", kind, name}, RunOpts{AllowError: true})
+	if err != nil {
+		if strings.Contains(err.Error(), "Error from server (NotFound)") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (r ClusterResource) UID() string {
 	uid := r.res.UID()
 	if len(uid) == 0 {

--- a/test/e2e/custom_wait_rules_test.go
+++ b/test/e2e/custom_wait_rules_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -117,5 +118,146 @@ status:
 		require.Contains(t, res, "Current state as Failed")
 
 		require.Contains(t, err.Error(), "kapp: Error: waiting on reconcile crontab/my-new-cron-object-1")
+	})
+}
+
+func TestYttWaitRules_WithUnBlockBlockedChanges(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	yaml := `
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+
+waitRules:
+  - ytt:
+      funcContractV1:
+        resource.star: |
+          def is_done(resource):
+              state = resource.status.currentState
+              if state == "Progressing":
+                return {"done": False, "unblockBlockedChanges": True, "message": "Unblock blocked changes"}
+              elif state == "Running":
+                return {"done": True, "successful": True, "message": "Current state as Running"}
+              else:
+                return {"done": True, "successful": False, "message": "Not in Failed or Running state"}
+              end
+          end
+    resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: stable.example.com/v1, kind: CronTab}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+            status:
+              type: object
+              properties:
+                currentState:
+                  type: string
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+---
+apiVersion: "stable.example.com/v1"
+kind: CronTab
+metadata:
+  name: my-new-cron-object-1
+  annotations:
+    kapp.k14s.io/change-group: "cr"
+spec:
+  cronSpec: "* * * * */5"
+  image: my-awesome-cron-image
+status:
+  currentState: Progressing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  annotations:
+    kapp.k14s.io/change-rule: "upsert after upserting cr"`
+
+	name := "test-custom-wait-rule-contract-v1"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	go func() {
+		for {
+			time.Sleep(1 * time.Second)
+			exists, err := ClusterResourceExists("ConfigMap", "test-cm", kubectl)
+			require.NoError(t, err, "Expected error to not have occurred")
+			if exists {
+				break
+			}
+		}
+		patch := `[{ "op": "replace", "path": "/status/currentState", "value": "Running"}]`
+		PatchClusterResource("CronTab", "my-new-cron-object-1", env.Namespace, patch, kubectl)
+	}()
+
+	logger.Section("deploy resource with current state as progressing", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{
+			StdinReader: strings.NewReader(yaml)})
+
+		out = strings.TrimSpace(replaceSpaces(replaceTarget(replaceTs(out))))
+
+		expectedOutput := strings.TrimSpace(replaceSpaces(`Changes
+
+Namespace  Name                         Kind                      Age  Op      Op st.  Wait to    Rs  Ri  $
+(cluster)  crontabs.stable.example.com  CustomResourceDefinition  -    create  -       reconcile  -   -  $
+kapp-test  my-new-cron-object-1         CronTab                   -    create  -       reconcile  -   -  $
+^          test-cm                      ConfigMap                 -    create  -       reconcile  -   -  $
+
+Op:      3 create, 0 delete, 0 update, 0 noop, 0 exists
+Wait to: 3 reconcile, 0 delete, 0 noop
+
+<replaced>: ---- applying 1 changes [0/3 done] ----
+<replaced>: create customresourcedefinition/crontabs.stable.example.com (apiextensions.k8s.io/v1) cluster
+<replaced>: ---- waiting on 1 changes [0/3 done] ----
+<replaced>: ok: reconcile customresourcedefinition/crontabs.stable.example.com (apiextensions.k8s.io/v1) cluster
+<replaced>: ---- applying 1 changes [1/3 done] ----
+<replaced>: create crontab/my-new-cron-object-1 (stable.example.com/v1) namespace: kapp-test
+<replaced>: ---- waiting on 1 changes [1/3 done] ----
+<replaced>: ongoing: reconcile crontab/my-new-cron-object-1 (stable.example.com/v1) namespace: kapp-test
+<replaced>:  ^ Allowing blocked changes to proceed: Unblock blocked changes
+<replaced>: ---- applying 1 changes [2/3 done] ----
+<replaced>: create configmap/test-cm (v1) namespace: kapp-test
+<replaced>: ---- waiting on 2 changes [1/3 done] ----
+<replaced>: ok: reconcile configmap/test-cm (v1) namespace: kapp-test
+<replaced>: ---- waiting on 1 changes [2/3 done] ----
+<replaced>: ok: reconcile crontab/my-new-cron-object-1 (stable.example.com/v1) namespace: kapp-test
+<replaced>:  ^ Current state as Running
+<replaced>: ---- applying complete [3/3 done] ----
+<replaced>: ---- waiting complete [3/3 done] ----
+
+Succeeded`))
+		require.Equal(t, expectedOutput, out)
 	})
 }

--- a/test/e2e/custom_wait_rules_test.go
+++ b/test/e2e/custom_wait_rules_test.go
@@ -121,7 +121,7 @@ status:
 	})
 }
 
-func TestYttWaitRules_WithUnBlockBlockedChanges(t *testing.T) {
+func TestYttWaitRules_WithUnblockChanges(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
@@ -138,7 +138,7 @@ waitRules:
           def is_done(resource):
               state = resource.status.currentState
               if state == "Progressing":
-                return {"done": False, "unblockBlockedChanges": True, "message": "Unblock blocked changes"}
+                return {"done": False, "unblockChanges": True, "message": "Unblock blocked changes"}
               elif state == "Running":
                 return {"done": True, "successful": True, "message": "Current state as Running"}
               else:

--- a/test/e2e/order_test.go
+++ b/test/e2e/order_test.go
@@ -231,8 +231,7 @@ waitRules:
   conditionMatchers:
   - type: Progressing
     status: "True"
-    success: true
-    supportsUnblockingChanges: true
+    unblockChanges: true
   - type: Available
     status: "True"
     success: true
@@ -289,7 +288,7 @@ Wait to: 2 reconcile, 0 delete, 0 noop
 <replaced>: ongoing: reconcile deployment/simple-app (apps/v1) namespace: kapp-test
 <replaced>:  ^ Waiting for generation 2 to be observed
 <replaced>: ongoing: reconcile deployment/simple-app (apps/v1) namespace: kapp-test
-<replaced>:  ^ Allowing blocked changes to proceed: Encountered successful condition Progressing == True: ReplicaSetUpdated
+<replaced>:  ^ Allowing blocked changes to proceed: Encountered condition Progressing == True: ReplicaSetUpdated
 <replaced>: ---- applying 1 changes [1/2 done] ----
 <replaced>: create service/simple-app (v1) namespace: kapp-test
 <replaced>: ---- waiting on 2 changes [0/2 done] ----


### PR DESCRIPTION
Fixes: #427 

`unblockChanges` can be set true for a condition in wait rules of a resource, which will unblock all resources that are dependent on this resource.

`Example`
```
apiVersion: kapp.k14s.io/v1alpha1
kind: Config
waitRules:
- supportsObservedGeneration: true
  conditionMatchers:
  - type: Progressing
    status: "True"
    success: true
    unblockChanges: true
  - type: Available
    status: "True"
    success: true
  resourceMatchers:
  - apiVersionKindMatcher: {apiVersion: apps/v1, kind: Deployment}
---
apiVersion: v1
kind: Service
metadata:
  name: simple-app
  annotations:
    kapp.k14s.io/change-rule: "upsert after upserting dep"
...
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: simple-app
  annotations:
    kapp.k14s.io/change-group: "dep"
...
```

In the above example, the service will be created after the deployment, based on the change group and change rules. But the `Progressing` condition on the deployment has the `unblockChanges` set to true (in the wait rules provided as part of config) and therefore the service will be created as soon as that condition is met.