### PR TITLE
Check match for status.ReadyReplicas with spec.Replicas for kapp to wait till deployment reconciliation 

### DIFF
--- a/pkg/kapp/resourcesmisc/apps_v1_deployment.go
+++ b/pkg/kapp/resourcesmisc/apps_v1_deployment.go
@@ -75,6 +75,10 @@ func (s AppsV1Deployment) IsDoneApplying() DoneApplyState {
 			"Waiting for %d unavailable replicas", dep.Status.UnavailableReplicas)}
 	}
 
+	if dep.Spec.Replicas != nil && dep.Status.ReadyReplicas < *dep.Spec.Replicas {
+		return DoneApplyState{Done: false, Message: fmt.Sprintf(
+			"Waiting for %d/%d replicas to be ready", *dep.Spec.Replicas-dep.Status.ReadyReplicas, *dep.Spec.Replicas)}
+	}
 	return DoneApplyState{Done: true, Successful: true}
 }
 


### PR DESCRIPTION
**Fixes:**  Kapp is exiting without waiting for the reconciliation and saying deployment succeeded. 
**Cause:** Kapp has check on status.UnavailableReplicas to verify the status of deployment which was not enough for some specific case ( if kapp read the yaml before  status.UnavailableReplicas got updated. Ref: https://github.com/vmware-tanzu/carvel-kapp/issues/448 )
**Solution:** Added check on status.ReadyReplicas with spec.Replicas to have double confirmation about the status of deployment.


**Acceptance Criteria:**
> With deploy strategy "RECREATE", KAPP should wait for reconciliation for the operations:
- [x]  Fresh deploy of an application
- [x]  Update in existing deployment (like change image)
- [x]  Increasing number of replicas (scaleUp)
- [x]  Decreasing number of replicas (scaleDown)
- [x]  Delete

> With no deploy strategy, KAPP should wait for reconciliation for the operations:
- [x]  Fresh deploy of an application
- [x]  Update in existing deployment (like change image)
- [x]  Increasing number of replicas (scaleUp)
- [x]  Decreasing number of replicas (scaleDown)
- [x]  Delete

