### PR TITLE
Skip ownership check for resources with `exists` annotation

### DIFF
--- a/pkg/kapp/diff/change.go
+++ b/pkg/kapp/diff/change.go
@@ -20,11 +20,6 @@ const (
 	ChangeOpNoop   ChangeOp = "noop"
 )
 
-const (
-	ExistsAnnKey = "kapp.k14s.io/exists" // Value is ignored
-	NoopAnnKey   = "kapp.k14s.io/noop"   // value is ignored
-)
-
 type Change interface {
 	NewOrExistingResource() ctlres.Resource
 	NewResource() ctlres.Resource
@@ -84,7 +79,7 @@ func (d *ChangeImpl) AppliedResource() ctlres.Resource  { return d.appliedRes }
 
 func (d *ChangeImpl) Op() ChangeOp {
 	if d.newRes != nil {
-		if _, hasNoopAnnotation := d.newRes.Annotations()[NoopAnnKey]; hasNoopAnnotation {
+		if _, hasNoopAnnotation := d.newRes.Annotations()[ctlres.NoopAnnKey]; hasNoopAnnotation {
 			return ChangeOpNoop
 		}
 	}
@@ -169,6 +164,6 @@ func (d *ChangeImpl) calculateOpsDiff() OpsDiff {
 }
 
 func (d *ChangeImpl) newResHasExistsAnnotation() bool {
-	_, hasExistsAnnotation := d.newRes.Annotations()[ExistsAnnKey]
+	_, hasExistsAnnotation := d.newRes.Annotations()[ctlres.ExistsAnnKey]
 	return hasExistsAnnotation
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Skip ownership check for resources with `kapp.k14s.io/exists` and `kapp.k14s.io/noop` annotations as these resources could be created by another kapp app.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #457 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
