### PR TITLE
Add status code check for http file sources

### DIFF
--- a/pkg/kapp/resources/file_sources_test.go
+++ b/pkg/kapp/resources/file_sources_test.go
@@ -1,0 +1,84 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPFileSources(t *testing.T) {
+	url := "http://example.com/some/path"
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, req.URL.String(), url)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	fileSource := ctlres.NewHTTPFileSource(url)
+	fileSource.Client = client
+	body, err := fileSource.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("OK"), body)
+
+	// 2xx Status Codes
+	client = NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, req.URL.String(), url)
+		return &http.Response{
+			StatusCode: http.StatusIMUsed,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	fileSource = ctlres.NewHTTPFileSource(url)
+	fileSource.Client = client
+	body, err = fileSource.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("OK"), body)
+
+	// Non-OK HTTP Status Code
+	status := "404 Not Found"
+	client = NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, req.URL.String(), url)
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     status,
+			Header:     make(http.Header),
+		}
+	})
+
+	fileSource = ctlres.NewHTTPFileSource(url)
+	fileSource.Client = client
+	body, err = fileSource.Bytes()
+	require.EqualError(t, err, fmt.Sprintf("Requesting URL '%s': %s", url, status))
+}
+
+// NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Use http.Client instead of http to make get calls
- Add status code check to error out for non OK http status codes
   (OK = 2xx)
- Add unit tests for http file sources

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #521 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:
Current behaviour
```bash
$ kapp deploy -a test -f https://github.com/fake/path/
Target cluster 'https://192.168.64.93:8443' (nodes: minikube)

kapp: Error: error converting YAML to JSON: yaml: line 163: mapping values are not allowed in this context
```

Expected behaviour:
```bash
$ /kapp deploy -a test -f https://github.com/fake/path/                                      
Target cluster 'https://192.168.64.93:8443' (nodes: minikube)

kapp: Error: Requesting URL 'https://github.com/fake/path/': 404 Not Found
```
