### PR TITLE
Enhance tty experience

### DIFF
--- a/pkg/kapp/cmd/app/delete.go
+++ b/pkg/kapp/cmd/app/delete.go
@@ -47,6 +47,7 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
 		Annotations: map[string]string{
 			cmdcore.AppHelpGroup.Key: cmdcore.AppHelpGroup.Value,
+			TTYByDefaultKey:          "",
 		},
 	}
 	o.AppFlags.Set(cmd, flagsFactory)

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	TTYByDefaultKey = "cli.carvel.dev/tty-by-default"
+)
+
 type DeployOptions struct {
 	ui          ui.UI
 	depsFactory cmdcore.DepsFactory
@@ -56,6 +60,7 @@ func NewDeployCmd(o *DeployOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
 		Annotations: map[string]string{
 			cmdcore.AppHelpGroup.Key: cmdcore.AppHelpGroup.Value,
+			TTYByDefaultKey:          "",
 		},
 		Example: `
   # Deploy app 'app1' based on config files in config/

--- a/pkg/kapp/cmd/appgroup/delete.go
+++ b/pkg/kapp/cmd/appgroup/delete.go
@@ -39,9 +39,10 @@ func NewDeleteOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.L
 
 func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Delete app group",
-		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Use:         "delete",
+		Short:       "Delete app group",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.AppGroupFlags.Set(cmd, flagsFactory)
 	o.AppFlags.DiffFlags.SetWithPrefix("diff", cmd)

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -42,10 +42,11 @@ func NewDeployOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.L
 
 func NewDeployCmd(o *DeployOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "deploy",
-		Aliases: []string{"d", "dep"},
-		Short:   "Deploy app group",
-		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Use:         "deploy",
+		Aliases:     []string{"d", "dep"},
+		Short:       "Deploy app group",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.AppGroupFlags.Set(cmd, flagsFactory)
 	o.DeployFlags.Set(cmd)

--- a/pkg/kapp/cmd/ui_flags.go
+++ b/pkg/kapp/cmd/ui_flags.go
@@ -19,8 +19,6 @@ type UIFlags struct {
 }
 
 func (f *UIFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
-	// Default tty to true: https://github.com/vmware-tanzu/carvel-kapp/issues/28
-	cmd.PersistentFlags().BoolVar(&f.TTY, "tty", true, "Force TTY-like output")
 	cmd.PersistentFlags().BoolVar(&f.Color, "color", true, "Set color output")
 	cmd.PersistentFlags().BoolVar(&f.JSON, "json", false, "Output as JSON")
 	cmd.PersistentFlags().BoolVarP(&f.NonInteractive, "yes", "y", false, "Assume yes for any prompt")
@@ -28,8 +26,6 @@ func (f *UIFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
 }
 
 func (f *UIFlags) ConfigureUI(ui *ui.ConfUI) {
-	ui.EnableTTY(f.TTY)
-
 	if f.Color {
 		ui.EnableColor()
 	}

--- a/test/e2e/exists_ann_test.go
+++ b/test/e2e/exists_ann_test.go
@@ -101,7 +101,7 @@ Succeeded`
 	})
 
 	logger.Section("inspecting app", func() {
-		out, _ := kapp.RunWithOpts([]string{"inspect", "-a", name},
+		out, _ := kapp.RunWithOpts([]string{"inspect", "-a", name, "--tty=true"},
 			RunOpts{})
 		out = strings.TrimSpace(replaceTarget(replaceAgeStr(replaceSpaces(replaceTs(out)))))
 

--- a/test/e2e/noop_ann_test.go
+++ b/test/e2e/noop_ann_test.go
@@ -90,7 +90,7 @@ Succeeded`
 	})
 
 	logger.Section("inspecting app", func() {
-		out, _ := kapp.RunWithOpts([]string{"inspect", "-a", name},
+		out, _ := kapp.RunWithOpts([]string{"inspect", "-a", name, "--tty=true"},
 			RunOpts{})
 		out = strings.TrimSpace(replaceTarget(replaceAgeStr(replaceSpaces(replaceTs(out)))))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Currently default value of `--tty` is true and therefore even when using `non tty` outputs like files, CIs, users have to manually set the value of `--tty` flag to false.
- Set default value of `--tty` to false.
- Set default value of `--tty` to true for `deploy` and `delete` command. This is done to ensure that even while using CIs, `kapp deploy` will show all the logs. `--tty=false` can still be used if less verbose output is desired.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #239

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Default value of tty flag is set to false for commands other than deploy and delete
```

#### Additional Notes for your reviewer:
The flag is now added to each of the commands separately instead of a persistent flag on the root command. Therefore it's no longer a global flag.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
