### PR TITLE
Default rebase rules for openshift cluster

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -64,6 +64,16 @@ rebaseRules:
   resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: v1, kind: Namespace}
 
+# Openshift adds some annotations and labels to namespaces
+- paths:
+  - [metadata, annotations, openshift.io/sa.scc.mcs]
+  - [metadata, annotations, openshift.io/sa.scc.supplemental-groups]
+  - [metadata, annotations, openshift.io/sa.scc.uid-range]
+  type: copy
+  sources: [new, existing]
+  resourceMatchers:
+  - apiVersionKindMatcher: {apiVersion: v1, kind: Namespace}
+
 # PVC
 - paths:
   - [metadata, annotations, pv.kubernetes.io/bind-completed]

--- a/test/e2e/cluster_resource.go
+++ b/test/e2e/cluster_resource.go
@@ -59,6 +59,10 @@ func RemoveClusterResource(t *testing.T, kind, name, ns string, kubectl Kubectl)
 	}
 }
 
+func PatchClusterResource(kind, name, ns, patch string, kubectl Kubectl) {
+	kubectl.Run([]string{"patch", kind, name, "--type=json", "--patch", patch, "-n", ns})
+}
+
 func (r ClusterResource) UID() string {
 	uid := r.res.UID()
 	if len(uid) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add some default rebase rules for openshift cluster.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
