### PR TITLE
Ignore rules for aggregate ClusterRoles

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -170,6 +170,25 @@ rebaseRules:
             hasAnnotationMatcher:
               keys: [kapp.k14s.io/disable-default-secretgen-rebase-rules]
 
+# aggregated ClusterRole rules are filled in by the control plane at runtime
+# refs https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+- paths:
+  - [rules]
+  type: copy
+  sources: [existing]
+  resourceMatchers:
+  - andMatcher:
+      matchers:
+      - anyMatcher:
+          matchers:
+          - apiVersionKindMatcher: {kind: ClusterRole, apiVersion: rbac.authorization.k8s.io/v1}
+          - apiVersionKindMatcher: {kind: ClusterRole, apiVersion: rbac.authorization.k8s.io/v1alpha1}
+          - apiVersionKindMatcher: {kind: ClusterRole, apiVersion: rbac.authorization.k8s.io/v1beta1}
+      - notMatcher:
+          matcher:
+            emptyFieldMatcher:
+              path: [aggregationRule]
+
 diffAgainstLastAppliedFieldExclusionRules:
 - path: [metadata, annotations, "deployment.kubernetes.io/revision"]
   resourceMatchers: *appsV1DeploymentWithRevAnnKey


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

Aggregate ClusterRole have their rules filled in by the control plane at
runtime. There is no need for kapp to manage this field as it will only
create churn that the control plane has to then undo.

By adding a default rebase rule for ClusterRoles that have an
aggregationRule field set, we can ignore the rules on update.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Ignore rules field for aggregate ClusterRole
```

#### Additional Notes for your reviewer:

Refs https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
