### PR TITLE
Apply as many changes as possible with error summary at end

### DIFF
--- a/pkg/kapp/clusterapply/cluster_change.go
+++ b/pkg/kapp/clusterapply/cluster_change.go
@@ -280,7 +280,7 @@ func (c *ClusterChange) applyErr(err error) error {
 		}
 	}
 
-	return fmt.Errorf("Applying %s: %s%s", c.ApplyDescription(),
+	return fmt.Errorf("%s: %s%s", c.ApplyDescription(),
 		uierrs.NewSemiStructuredError(err), hintMsg)
 }
 

--- a/pkg/kapp/cmd/app/apply_flags.go
+++ b/pkg/kapp/cmd/app/apply_flags.go
@@ -50,6 +50,8 @@ func (s *ApplyFlags) SetWithDefaults(prefix string, defaults ApplyFlags, cmd *co
 	cmd.Flags().StringVar(&s.AddOrUpdateChangeOpts.DefaultUpdateStrategy, prefix+"apply-default-update-strategy",
 		defaults.AddOrUpdateChangeOpts.DefaultUpdateStrategy, "Change default update strategy")
 
+	cmd.Flags().BoolVar(&s.ExitEarlyOnApplyError, prefix+"exit-early-on-apply-error", true, "Exit quickly on apply failure")
+
 	cmd.Flags().BoolVar(&s.Wait, prefix+"wait", defaults.Wait, "Set to wait for changes to be applied")
 	cmd.Flags().BoolVar(&s.WaitIgnored, prefix+"wait-ignored", defaults.WaitIgnored, "Set to wait for ignored changes to be applied")
 
@@ -63,6 +65,8 @@ func (s *ApplyFlags) SetWithDefaults(prefix string, defaults ApplyFlags, cmd *co
 		5, "Maximum number of concurrent wait operations")
 
 	cmd.Flags().BoolVar(&s.ExitStatus, prefix+"apply-exit-status", false, "Return specific exit status based on number of changes")
+
+	cmd.Flags().BoolVar(&s.ExitEarlyOnWaitError, prefix+"exit-early-on-wait-error", true, "Exit quickly on wait failure")
 }
 
 func mustParseDuration(str string) time.Duration {

--- a/test/e2e/apply_wait_error_test.go
+++ b/test/e2e/apply_wait_error_test.go
@@ -1,0 +1,253 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyWaitErrors(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	yaml1 := `
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job-fail
+  annotations:
+    kapp.k14s.io/change-group: "job-fail"
+spec:
+  template:
+    metadata:
+      name: my-job-fail
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: my-job-fail
+          image: busybox
+          command: [ "sh", "-c", "exit 1" ]
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job-fail-2
+  annotations:
+    kapp.k14s.io/change-group: "job-fail"
+spec:
+  template:
+    metadata:
+      name: my-job-fail-2
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: my-job-fail-2
+          image: busybox
+          command: [ "sh", "-c", "exit 1" ]
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job-succeed
+  annotations:
+    kapp.k14s.io/change-group: "job-succeed"
+    kapp.k14s.io/change-rule: "upsert before upserting service-not-deployed"
+spec:
+  template:
+    metadata:
+      name: my-job-succeed
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: my-job-succeed
+          image: busybox
+          command: [ "sh", "-c", "exit 0" ]
+  backoffLimit: 0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-succeed
+  annotations:
+    kapp.k14s.io/change-rule: "upsert after upserting job-succeed"
+spec:
+  ports:
+  - port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-fail
+  annotations:
+    kapp.k14s.io/change-group: "service-fail"
+    kapp.k14s.io/change-rule: "upsert after upserting job-succeed"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-not-deployed
+  annotations:
+    kapp.k14s.io/change-group: "service-not-deployed"
+    kapp.k14s.io/change-rule: "upsert after upserting job-fail"
+spec:
+  ports:
+  - port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-not-deployed-2
+  annotations:
+    kapp.k14s.io/change-rule: "upsert after upserting service-fail"
+spec:
+  ports:
+  - port: 80
+`
+
+	name := "test-multiple-errors"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy with multiple errors and exit early on error set to false", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--exit-early-on-apply-error=false", "--exit-early-on-wait-error=false"},
+			RunOpts{StdinReader: strings.NewReader(yaml1), AllowError: true})
+
+		expectedErrs := []string{
+			`kapp: Error:`,
+			fmt.Sprintf(`- waiting on reconcile job/my-job-fail-2 (batch/v1) namespace: %s: Finished unsuccessfully (Failed with reason BackoffLimitExceeded: Job has reached the specified backoff limit)`, env.Namespace),
+			fmt.Sprintf(`- waiting on reconcile job/my-job-fail (batch/v1) namespace: %s: Finished unsuccessfully (Failed with reason BackoffLimitExceeded: Job has reached the specified backoff limit)`, env.Namespace),
+			fmt.Sprintf(`- create service/service-fail (v1) namespace: %s: Creating resource service/service-fail (v1) namespace: kapp-test: API server says: Service "service-fail" is invalid: spec.ports: Required value (reason: Invalid)`, env.Namespace),
+		}
+
+		for _, expectedErr := range expectedErrs {
+			require.Containsf(t, err.Error(), expectedErr, "Expected to see expected err in output, but did not")
+		}
+
+		out := kapp.Run([]string{"inspect", "-a", name, "--filter-kind", "Service", "--json"})
+
+		expectedResources := []map[string]string{{
+			"age":             "<replaced>",
+			"kind":            "Service",
+			"name":            "service-succeed",
+			"namespace":       env.Namespace,
+			"owner":           "kapp",
+			"reconcile_info":  "",
+			"reconcile_state": "ok",
+		}}
+
+		inspectOut := uitest.JSONUIFromBytes(t, []byte(out))
+
+		require.Exactlyf(t, expectedResources, replaceAge(inspectOut.Tables[0].Rows), "Expected to see correct changes")
+	})
+}
+
+func TestExitEarlyOnApplyErrorFlag(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	yaml1 := `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-fail
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job-succeed
+  annotations:
+    kapp.k14s.io/change-group: "job-succeed"
+spec:
+  template:
+    metadata:
+      name: my-job-succeed
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: my-job-succeed
+          image: busybox
+          command: [ "sh", "-c", "exit 0" ]
+  backoffLimit: 0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-succeed
+  annotations:
+    kapp.k14s.io/change-rule: "upsert after upserting job-succeed"
+spec:
+  ports:
+  - port: 80
+`
+
+	name := "test-exit-early-on-apply-error"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	expectedErr := strings.ReplaceAll(`kapp: Error: create service/service-fail (v1) namespace: <test-ns>:
+  Creating resource service/service-fail (v1) namespace: <test-ns>:
+    API server says:
+      Service "service-fail" is invalid: spec.ports:
+        Required value (reason: Invalid)
+`, "<test-ns>", env.Namespace)
+
+	logger.Section("deploy with exit-early-on-apply-error=false", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--exit-early-on-apply-error=false"},
+			RunOpts{StdinReader: strings.NewReader(yaml1), AllowError: true})
+
+		require.Containsf(t, err.Error(), expectedErr, "Expected to see expected err in output, but did not")
+
+		out := kapp.Run([]string{"inspect", "-a", name, "--json", "--filter-kind", "Service"})
+
+		expectedResources := []map[string]string{{
+			"age":             "<replaced>",
+			"kind":            "Service",
+			"name":            "service-succeed",
+			"namespace":       env.Namespace,
+			"owner":           "kapp",
+			"reconcile_info":  "",
+			"reconcile_state": "ok",
+		}}
+
+		inspectOut := uitest.JSONUIFromBytes(t, []byte(out))
+
+		require.Exactlyf(t, expectedResources, replaceAge(inspectOut.Tables[0].Rows), "Expected to see correct changes")
+	})
+
+	cleanUp()
+
+	logger.Section("deploy with exit-early-on-apply-error=true", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{StdinReader: strings.NewReader(yaml1), AllowError: true})
+
+		require.Containsf(t, err.Error(), expectedErr, "Expected to see expected err in output, but did not")
+
+		out := kapp.Run([]string{"inspect", "-a", name, "--json", "--filter-kind", "Service"})
+
+		expectedResources := []map[string]string{}
+
+		inspectOut := uitest.JSONUIFromBytes(t, []byte(out))
+
+		require.Exactlyf(t, expectedResources, replaceAge(inspectOut.Tables[0].Rows), "Expected to see correct changes")
+	})
+}

--- a/test/e2e/formatted_error_test.go
+++ b/test/e2e/formatted_error_test.go
@@ -50,7 +50,7 @@ spec:
 
 	logger.Section("deploy with errors", func() {
 		expectedErr := strings.TrimSpace(`
-kapp: Error: Applying create job/successful-job (batch/v1) namespace: default:
+kapp: Error: create job/successful-job (batch/v1) namespace: default:
   Creating resource job/successful-job (batch/v1) namespace: default:
     API server says:
       Job.batch "successful-job" is invalid: 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Currently kapp errors out as soon as it detects an error while apply a resource or waiting for a resource, but we would want to apply as many changes as possible and return all the errors at end. If a change doesn't depend on a failed change then it should get applied.

- Changes that depend on failing changes shouldn't be applied
- `exit-early-on-apply-error` flag can be used to exit as soon as an error is encountered while applying changes (default true)
- `exit-early-on-wait-error` flag can be used to exit as soon as an error is encountered while waiting for changes (default true)

Sample gist for testing: https://gist.github.com/praveenrewar/2746318c5a273d13ed26497f34755638

TODO:
- [x] Add e2e test
- [x] Do more manual testing

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #426 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
