### PR TITLE
Set default e2e namespace and create it if needed

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -6,6 +6,13 @@ go clean -testcache
 
 export KAPP_BINARY_PATH="${KAPP_BINARY_PATH:-$PWD/kapp}"
 
+if [ -z "$KAPP_E2E_NAMESPACE" ]; then
+    echo "setting e2e namespace to: kapp-test";
+    export KAPP_E2E_NAMESPACE="kapp-test"
+fi
+# create ns if not exists because the `apply -f -` won't complain on a no-op if the ns already exists.
+kubectl create ns $KAPP_E2E_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
 go test ./test/e2e/ -timeout 60m -test.v $@
 
 echo E2E SUCCESS

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e -x -u
+set -e -x -o pipefail
 
 go clean -testcache
 


### PR DESCRIPTION
Signed-off-by: Víctor Martínez Bevià <vicmarbev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Sets a default value for KAPP_E2E_NAMESPACE if the variable is not set. Creates the namespace if it doesn't exist. 

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #538 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
Followed the solution at: https://github.com/vmware-tanzu/carvel-kapp-controller/pull/752

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
