### PR TITLE
Update release workflow to have ./ before artefacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,11 @@ jobs:
               }
             }
             console.log(checksums)
-            return `${checksums['kapp-darwin-amd64']}  kapp-darwin-amd64
-            ${checksums['kapp-darwin-arm64']}  kapp-darwin-arm64
-            ${checksums['kapp-linux-amd64']}  kapp-linux-amd64
-            ${checksums['kapp-linux-arm64']}  kapp-linux-arm64
-            ${checksums['kapp-windows-amd64.exe']}  kapp-windows-amd64.exe`
+            return `${checksums['kapp-darwin-amd64']}  ./kapp-darwin-amd64
+            ${checksums['kapp-darwin-arm64']}  ./kapp-darwin-arm64
+            ${checksums['kapp-linux-amd64']}  ./kapp-linux-amd64
+            ${checksums['kapp-linux-arm64']}  ./kapp-linux-arm64
+            ${checksums['kapp-windows-amd64.exe']}  ./kapp-windows-amd64.exe`
 
       - name: verify uploaded artifacts
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Update release workflow to have `./` before artefacts. This format is required by the carvel-setup-action and carvel-release-scripts
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
