### PR TITLE
Add `--appMetadataFile` deploy flag

### DIFF
--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -558,6 +558,11 @@ func (a *RecordedApp) update(doFunc func(*Meta)) error {
 
 	change.Data = meta.AsData()
 
+	_, err = a.setMeta(*change)
+	if err != nil {
+		return err
+	}
+
 	_, err = a.coreClient.CoreV1().ConfigMaps(a.nsName).Update(context.TODO(), change, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("Updating app: %s", err)

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -225,8 +226,24 @@ func (o *DeployOptions) Run() error {
 		}
 
 		// Remove unused GVs and GKs
-		return app.UpdateUsedGVsAndGKs(failingAPIServicesPolicy.GVs(newResources, nil),
+		err = app.UpdateUsedGVsAndGKs(failingAPIServicesPolicy.GVs(newResources, nil),
 			NewUsedGKsScope(newResources).GKs())
+		if err != nil {
+			return err
+		}
+
+		if o.DeployFlags.AppMetadataFile != "" {
+			meta, err := app.Meta()
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(o.DeployFlags.AppMetadataFile, []byte(meta.AsString()), os.ModePerm)
+			if err != nil {
+				return err
+			}
+		}
+
+		return err
 	})
 	if err != nil {
 		return err

--- a/pkg/kapp/cmd/app/deploy_flags.go
+++ b/pkg/kapp/cmd/app/deploy_flags.go
@@ -21,8 +21,9 @@ type DeployFlags struct {
 
 	AppChangesMaxToKeep int
 
-	Logs    bool
-	LogsAll bool
+	Logs            bool
+	LogsAll         bool
+	AppMetadataFile string
 }
 
 func (s *DeployFlags) Set(cmd *cobra.Command) {
@@ -48,4 +49,5 @@ func (s *DeployFlags) Set(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&s.Logs, "logs", true, fmt.Sprintf("Show logs from Pods annotated as '%s'", deployLogsAnnKey))
 	cmd.Flags().BoolVar(&s.LogsAll, "logs-all", false, "Show logs from all Pods")
+	cmd.Flags().StringVar(&s.AppMetadataFile, "app-metadata-file-output", "", "Set filename to write app metadata")
 }

--- a/test/e2e/app_change_test.go
+++ b/test/e2e/app_change_test.go
@@ -5,12 +5,15 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestAppChange(t *testing.T) {
@@ -88,4 +91,87 @@ spec:
 
 		require.Equal(t, 2, len(resp2.Tables[0].Rows), "Expected to have 2 app-changes")
 	})
+}
+
+func TestAppKindChangeWithMetadataOutput(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	yaml1 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  annotations:
+    kapp.k14s.io/versioned: ""
+data:
+  redis-config: |
+    maxmemory 3mb
+    maxmemory-policy allkeys-lru
+`
+
+	yaml2 := `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kapp-secret-1
+  namespace: kapp-namespace-2
+`
+
+	name := "test-app-change"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	firstDeploy, err := os.CreateTemp(os.TempDir(), "output1")
+	assert.NoError(t, err)
+	secondDeploy, err := os.CreateTemp(os.TempDir(), "output2")
+	assert.NoError(t, err)
+
+	defer func() {
+		os.Remove(firstDeploy.Name())
+		os.Remove(secondDeploy.Name())
+	}()
+
+	logger.Section("deploy app", func() {
+		kapp.RunWithOpts([]string{"deploy", "--app-metadata-file-output", firstDeploy.Name(), "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+	})
+
+	logger.Section("deploy with changes", func() {
+		kapp.RunWithOpts([]string{"deploy", "--app-metadata-file-output", secondDeploy.Name(), "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+	})
+
+	configMapFirstDeploy, err := os.ReadFile(firstDeploy.Name())
+	assert.NoError(t, err)
+
+	firstConfigMap := yamlSubset{}
+	require.NoError(t, yaml.Unmarshal(configMapFirstDeploy, &firstConfigMap))
+	require.Equal(t, yamlSubset{LastChange: lastChange{Namespaces: []string{env.Namespace}}, UsedGKs: []usedGK{{Group: "", Kind: "ConfigMap"}}}, firstConfigMap)
+
+	configMapSecondDeploy, err := os.ReadFile(secondDeploy.Name())
+	assert.NoError(t, err)
+
+	secondConfigMap := yamlSubset{}
+	require.NoError(t, yaml.Unmarshal(configMapSecondDeploy, &secondConfigMap))
+	require.Equal(t, yamlSubset{LastChange: lastChange{Namespaces: []string{env.Namespace}}, UsedGKs: []usedGK{{Group: "", Kind: "Secret"}}}, secondConfigMap)
+}
+
+type usedGK struct {
+	Group string `yaml:"Group"`
+	Kind  string `yaml:"Kind"`
+}
+
+type lastChange struct {
+	Namespaces []string `yaml:"namespaces"`
+}
+
+type yamlSubset struct {
+	LastChange lastChange `yaml:"lastChange"`
+	UsedGKs    []usedGK   `yaml:"usedGKs"`
 }


### PR DESCRIPTION
TODO: 
- [x] remove any hardcoding left over
- [x] fix up commits

#### What this PR does / why we need it:
related to: https://github.com/vmware-tanzu/carvel-kapp-controller/pull/799

#### Does this PR introduce a user-facing change?
Yes, it introduces a new flag to write the app metadata config map to disk

```release-note
- Adds deploy flag `--appMetadataFile` to write an app metadata file to disk
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
