### PR TITLE
Add flag to use default label scoping rules

### DIFF
--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -320,7 +320,7 @@ func (o *DeployOptions) newResources(
 	}
 
 	err = labeledResources.Prepare(newResources, conf.OwnershipLabelMods(),
-		conf.LabelScopingMods(), conf.AdditionalLabels())
+		conf.LabelScopingMods(o.DeployFlags.DefaultLabelScopingRules), conf.AdditionalLabels())
 	if err != nil {
 		return nil, ctlconf.Conf{}, nil, nil, err
 	}

--- a/pkg/kapp/cmd/app/deploy_flags.go
+++ b/pkg/kapp/cmd/app/deploy_flags.go
@@ -21,6 +21,8 @@ type DeployFlags struct {
 
 	AppChangesMaxToKeep int
 
+	DefaultLabelScopingRules bool
+
 	Logs            bool
 	LogsAll         bool
 	AppMetadataFile string
@@ -44,6 +46,9 @@ func (s *DeployFlags) Set(cmd *cobra.Command) {
 		100, "Concurrency to check for existing non-labeled resources")
 	cmd.Flags().BoolVar(&s.OverrideOwnershipOfExistingResources, "dangerous-override-ownership-of-existing-resources",
 		false, "Steal existing resources from another app")
+
+	cmd.Flags().BoolVar(&s.DefaultLabelScopingRules, "default-label-scoping-rules",
+		true, "Use default label scoping rules")
 
 	cmd.Flags().IntVar(&s.AppChangesMaxToKeep, "app-changes-max-to-keep", ctlapp.AppChangesMaxToKeepDefault, "Maximum number of app changes to keep")
 

--- a/pkg/kapp/config/conf.go
+++ b/pkg/kapp/config/conf.go
@@ -122,11 +122,14 @@ func (c Conf) WaitRules() []WaitRule {
 	return rules
 }
 
-func (c Conf) LabelScopingMods() func(kvs map[string]string) []ctlres.StringMapAppendMod {
+func (c Conf) LabelScopingMods(defaultRules bool) func(kvs map[string]string) []ctlres.StringMapAppendMod {
 	return func(kvs map[string]string) []ctlres.StringMapAppendMod {
 		var mods []ctlres.StringMapAppendMod
 		for _, config := range c.configs {
 			for _, rule := range config.LabelScopingRules {
+				if rule.IsDefault && !defaultRules {
+					continue
+				}
 				mods = append(mods, rule.AsMod(kvs))
 			}
 		}

--- a/pkg/kapp/config/config.go
+++ b/pkg/kapp/config/config.go
@@ -104,6 +104,7 @@ type OwnershipLabelRule struct {
 type LabelScopingRule struct {
 	ResourceMatchers []ResourceMatcher
 	Path             ctlres.Path
+	IsDefault        bool `json:"isDefault"`
 }
 
 type TemplateRule struct {

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -324,6 +324,7 @@ ownershipLabelRules:
 
 labelScopingRules:
 - path: [spec, selector]
+  isDefault: true
   resourceMatchers:
   - andMatcher:
       matchers:
@@ -339,6 +340,7 @@ labelScopingRules:
       - apiVersionKindMatcher: {apiVersion: v1, kind: Service}
 
 - path: [spec, selector, matchLabels]
+  isDefault: true
   resourceMatchers:
   - andMatcher:
       matchers:
@@ -350,6 +352,7 @@ labelScopingRules:
           matchers: *withPodTemplate
 
 - path: [spec, selector, matchLabels]
+  isDefault: true
   resourceMatchers:
   - andMatcher:
       matchers:

--- a/test/e2e/default_label_scoping_test.go
+++ b/test/e2e/default_label_scoping_test.go
@@ -1,0 +1,209 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultLabelScopingRulesFlag(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
+
+	name := "test-default-label-scoping-rules"
+
+	yaml := `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple-app
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    simple-app: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-app
+spec:
+  selector:
+    matchLabels:
+      simple-app: ""
+  template:
+    metadata:
+      labels:
+        simple-app: ""
+    spec:
+      containers:
+      - name: simple-app
+        image: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
+        env:
+        - name: HELLO_MSG
+          value: stranger
+`
+	config := `
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+
+labelScopingRules:
+- path: [spec, selector]
+  resourceMatchers:
+  - apiVersionKindMatcher: {apiVersion: v1, kind: Service}
+`
+
+	logger.Section("deploying app with default-label-scoping-rules", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-c", "--diff-run"},
+			RunOpts{StdinReader: strings.NewReader(yaml)})
+
+		expectedOut := `
+@@ create service/simple-app (v1) namespace: <test-ns> @@
+      0 + apiVersion: v1
+      1 + kind: Service
+      2 + metadata:
+      3 +   labels:
+      4 +     kapp.k14s.io/app: "-replaced-"
+      5 +     kapp.k14s.io/association: -replaced-
+      6 +   name: simple-app
+      7 +   namespace: <test-ns>
+      8 + spec:
+      9 +   ports:
+     10 +   - port: 80
+     11 +     targetPort: 80
+     12 +   selector:
+     13 +     kapp.k14s.io/app: "-replaced-"
+     14 +     simple-app: ""
+     15 + 
+@@ create deployment/simple-app (apps/v1) namespace: <test-ns> @@
+      0 + apiVersion: apps/v1
+      1 + kind: Deployment
+      2 + metadata:
+      3 +   labels:
+      4 +     kapp.k14s.io/app: "-replaced-"
+      5 +     kapp.k14s.io/association: -replaced-
+      6 +   name: simple-app
+      7 +   namespace: <test-ns>
+      8 + spec:
+      9 +   selector:
+     10 +     matchLabels:
+     11 +       kapp.k14s.io/app: "-replaced-"
+     12 +       simple-app: ""
+     13 +   template:
+     14 +     metadata:
+     15 +       labels:
+     16 +         kapp.k14s.io/app: "-replaced-"
+     17 +         kapp.k14s.io/association: -replaced-
+     18 +         simple-app: ""
+`
+		expectedOut = strings.ReplaceAll(expectedOut, "<test-ns>", env.Namespace)
+		require.Contains(t, replaceLabelValues(out), expectedOut, "Expected labels to match")
+	})
+
+	logger.Section("deploying app with default-label-scoping-rules=false", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-c", "--diff-run", "--default-label-scoping-rules=false"},
+			RunOpts{StdinReader: strings.NewReader(yaml)})
+
+		expectedOut := `
+@@ create service/simple-app (v1) namespace: <test-ns> @@
+      0 + apiVersion: v1
+      1 + kind: Service
+      2 + metadata:
+      3 +   labels:
+      4 +     kapp.k14s.io/app: "-replaced-"
+      5 +     kapp.k14s.io/association: -replaced-
+      6 +   name: simple-app
+      7 +   namespace: <test-ns>
+      8 + spec:
+      9 +   ports:
+     10 +   - port: 80
+     11 +     targetPort: 80
+     12 +   selector:
+     13 +     simple-app: ""
+     14 + 
+@@ create deployment/simple-app (apps/v1) namespace: <test-ns> @@
+      0 + apiVersion: apps/v1
+      1 + kind: Deployment
+      2 + metadata:
+      3 +   labels:
+      4 +     kapp.k14s.io/app: "-replaced-"
+      5 +     kapp.k14s.io/association: -replaced-
+      6 +   name: simple-app
+      7 +   namespace: <test-ns>
+      8 + spec:
+      9 +   selector:
+     10 +     matchLabels:
+     11 +       simple-app: ""
+     12 +   template:
+     13 +     metadata:
+     14 +       labels:
+     15 +         kapp.k14s.io/app: "-replaced-"
+     16 +         kapp.k14s.io/association: -replaced-
+     17 +         simple-app: ""
+`
+		expectedOut = strings.ReplaceAll(expectedOut, "<test-ns>", env.Namespace)
+		require.Contains(t, replaceLabelValues(out), expectedOut, "Expected labels to match")
+	})
+
+	logger.Section("deploying app with default-label-scoping-rules=false and custom label scoping rules", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "-c", "--diff-run", "--default-label-scoping-rules=false"},
+			RunOpts{StdinReader: strings.NewReader(yaml + config)})
+
+		expectedOut := `
+@@ create service/simple-app (v1) namespace: <test-ns> @@
+      0 + apiVersion: v1
+      1 + kind: Service
+      2 + metadata:
+      3 +   labels:
+      4 +     kapp.k14s.io/app: "-replaced-"
+      5 +     kapp.k14s.io/association: -replaced-
+      6 +   name: simple-app
+      7 +   namespace: <test-ns>
+      8 + spec:
+      9 +   ports:
+     10 +   - port: 80
+     11 +     targetPort: 80
+     12 +   selector:
+     13 +     kapp.k14s.io/app: "-replaced-"
+     14 +     simple-app: ""
+     15 + 
+@@ create deployment/simple-app (apps/v1) namespace: <test-ns> @@
+      0 + apiVersion: apps/v1
+      1 + kind: Deployment
+      2 + metadata:
+      3 +   labels:
+      4 +     kapp.k14s.io/app: "-replaced-"
+      5 +     kapp.k14s.io/association: -replaced-
+      6 +   name: simple-app
+      7 +   namespace: <test-ns>
+      8 + spec:
+      9 +   selector:
+     10 +     matchLabels:
+     11 +       simple-app: ""
+     12 +   template:
+     13 +     metadata:
+     14 +       labels:
+     15 +         kapp.k14s.io/app: "-replaced-"
+     16 +         kapp.k14s.io/association: -replaced-
+     17 +         simple-app: ""
+`
+		expectedOut = strings.ReplaceAll(expectedOut, "<test-ns>", env.Namespace)
+		require.Contains(t, replaceLabelValues(out), expectedOut, "Expected labels to match")
+	})
+}
+
+func replaceLabelValues(in string) string {
+	replaceAnns := regexp.MustCompile("kapp\\.k14s\\.io\\/app: .+")
+	in = replaceAnns.ReplaceAllString(in, `kapp.k14s.io/app: "-replaced-"`)
+	replaceAnns = regexp.MustCompile("kapp\\.k14s\\.io\\/association: .+")
+	return replaceAnns.ReplaceAllString(in, `kapp.k14s.io/association: -replaced-`)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add flag to use default label scoping rules.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #563 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Added --default-label-scoping-rules flag which can be used to enable or disable the default label scoping rules added during deploy.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
