### PR TITLE
Use diffAgainstLastAppliedFieldExclusionRules to exclude status field from diffs

### DIFF
--- a/pkg/kapp/clusterapply/changes_view.go
+++ b/pkg/kapp/clusterapply/changes_view.go
@@ -17,7 +17,7 @@ import (
 
 type ChangeView interface {
 	Resource() ctlres.Resource
-	ExistingResource() ctlres.Resource
+	ClusterOriginalResource() ctlres.Resource
 
 	ApplyOp() ClusterChangeApplyOp
 	ApplyStrategyOp() (ClusterChangeApplyStrategyOp, error)
@@ -105,8 +105,8 @@ func (v *ChangesView) Print(ui ui.UI) {
 			v.waitOpCode(view.WaitOp()),
 		)
 
-		if view.ExistingResource() != nil {
-			syncVal := NewValueResourceConverged(view.ExistingResource())
+		if view.ClusterOriginalResource() != nil {
+			syncVal := NewValueResourceConverged(view.ClusterOriginalResource())
 			row = append(row, syncVal.StateVal, syncVal.ReasonVal)
 		} else {
 			row = append(row,

--- a/pkg/kapp/clusterapply/cluster_change.go
+++ b/pkg/kapp/clusterapply/cluster_change.go
@@ -146,8 +146,8 @@ func (c *ClusterChange) WaitOp() ClusterChangeWaitOp {
 		// TODO associated resources
 		// If existing resource is not in a "done successful" state,
 		// indicate that this will be something we need to wait for
-		existingResState, _, existingErr := c.convergedResFactory.New(c.change.ExistingResource(), nil).IsDoneApplying()
-		if existingErr != nil || !(existingResState.Done && existingResState.Successful) {
+		resState, _, err := c.convergedResFactory.New(c.change.ClusterOriginalResource(), nil).IsDoneApplying()
+		if err != nil || !(resState.Done && resState.Successful) {
 			return ClusterChangeWaitOpOK
 		}
 		return ClusterChangeWaitOpNoop
@@ -254,8 +254,11 @@ func (c *ClusterChange) WaitDescription() string {
 	return fmt.Sprintf("%s %s", waitOpCodeUI[c.WaitOp()], c.change.NewOrExistingResource().Description())
 }
 
-func (c *ClusterChange) Resource() ctlres.Resource         { return c.change.NewOrExistingResource() }
-func (c *ClusterChange) ExistingResource() ctlres.Resource { return c.change.ExistingResource() }
+func (c *ClusterChange) Resource() ctlres.Resource { return c.change.NewOrExistingResource() }
+
+func (c *ClusterChange) ClusterOriginalResource() ctlres.Resource {
+	return c.change.ClusterOriginalResource()
+}
 
 func (c *ClusterChange) ConfigurableTextDiff() *ctldiff.ConfigurableTextDiff {
 	return c.change.ConfigurableTextDiff()

--- a/pkg/kapp/cmd/tools/diff.go
+++ b/pkg/kapp/cmd/tools/diff.go
@@ -95,8 +95,11 @@ type DiffChangeView struct {
 
 var _ ctlcap.ChangeView = DiffChangeView{}
 
-func (v DiffChangeView) Resource() ctlres.Resource         { return v.change.NewOrExistingResource() }
-func (v DiffChangeView) ExistingResource() ctlres.Resource { return v.change.ExistingResource() }
+func (v DiffChangeView) Resource() ctlres.Resource { return v.change.NewOrExistingResource() }
+
+func (v DiffChangeView) ClusterOriginalResource() ctlres.Resource {
+	return v.change.ClusterOriginalResource()
+}
 
 func (v DiffChangeView) ApplyOp() ctlcap.ClusterChangeApplyOp {
 	switch v.change.Op() {

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -41,13 +41,6 @@ rebaseRules:
   resourceMatchers:
   - allMatcher: {}
 
-# Copy over all status, since cluster owns that
-- path: [status]
-  type: copy
-  sources: [existing]
-  resourceMatchers:
-  - allMatcher: {}
-
 # Prefer user provided, but allow cluster set
 - paths:
   - [spec, clusterIP]
@@ -237,6 +230,10 @@ rebaseRules:
 diffAgainstLastAppliedFieldExclusionRules:
 - path: [metadata, annotations, "deployment.kubernetes.io/revision"]
   resourceMatchers: *appsV1DeploymentWithRevAnnKey
+
+- path: [status]
+  resourceMatchers:
+  - allMatcher: {}
 
 diffMaskRules:
 - path: [data]

--- a/pkg/kapp/diff/change.go
+++ b/pkg/kapp/diff/change.go
@@ -25,6 +25,7 @@ type Change interface {
 	NewResource() ctlres.Resource
 	ExistingResource() ctlres.Resource
 	AppliedResource() ctlres.Resource
+	ClusterOriginalResource() ctlres.Resource
 
 	Op() ChangeOp
 	ConfigurableTextDiff() *ConfigurableTextDiff
@@ -39,13 +40,16 @@ type ChangeImpl struct {
 	// appliedRes is an unmodified copy of what's being applied
 	appliedRes ctlres.Resource
 
+	// clusterOriginalRes is an unmodified copy of what's present on the cluster
+	clusterOriginalRes ctlres.Resource
+
 	configurableTextDiff *ConfigurableTextDiff
 	opsDiff              *OpsDiff
 }
 
 var _ Change = &ChangeImpl{}
 
-func NewChange(existingRes, newRes, appliedRes ctlres.Resource) *ChangeImpl {
+func NewChange(existingRes, newRes, appliedRes, clusterOriginalRes ctlres.Resource) *ChangeImpl {
 	if existingRes == nil && newRes == nil {
 		panic("Expected either existingRes or newRes be non-nil")
 	}
@@ -59,8 +63,11 @@ func NewChange(existingRes, newRes, appliedRes ctlres.Resource) *ChangeImpl {
 	if appliedRes != nil {
 		appliedRes = appliedRes.DeepCopy()
 	}
+	if clusterOriginalRes != nil {
+		clusterOriginalRes = clusterOriginalRes.DeepCopy()
+	}
 
-	return &ChangeImpl{existingRes: existingRes, newRes: newRes, appliedRes: appliedRes}
+	return &ChangeImpl{existingRes: existingRes, newRes: newRes, appliedRes: appliedRes, clusterOriginalRes: clusterOriginalRes}
 }
 
 func (d *ChangeImpl) NewOrExistingResource() ctlres.Resource {
@@ -73,9 +80,10 @@ func (d *ChangeImpl) NewOrExistingResource() ctlres.Resource {
 	panic("Not possible")
 }
 
-func (d *ChangeImpl) NewResource() ctlres.Resource      { return d.newRes }
-func (d *ChangeImpl) ExistingResource() ctlres.Resource { return d.existingRes }
-func (d *ChangeImpl) AppliedResource() ctlres.Resource  { return d.appliedRes }
+func (d *ChangeImpl) NewResource() ctlres.Resource             { return d.newRes }
+func (d *ChangeImpl) ExistingResource() ctlres.Resource        { return d.existingRes }
+func (d *ChangeImpl) AppliedResource() ctlres.Resource         { return d.appliedRes }
+func (d *ChangeImpl) ClusterOriginalResource() ctlres.Resource { return d.clusterOriginalRes }
 
 func (d *ChangeImpl) Op() ChangeOp {
 	if d.newRes != nil {

--- a/pkg/kapp/diff/change_factory.go
+++ b/pkg/kapp/diff/change_factory.go
@@ -58,7 +58,7 @@ func (f ChangeFactory) NewChangeAgainstLastApplied(existingRes, newRes ctlres.Re
 		return nil, err
 	}
 
-	return NewChange(existingRes, rebasedNewRes, newRes), nil
+	return NewChange(existingRes, rebasedNewRes, newRes, existingResForRebasing), nil
 }
 
 func (f ChangeFactory) NewExactChange(existingRes, newRes ctlres.Resource) (Change, error) {
@@ -85,7 +85,7 @@ func (f ChangeFactory) NewExactChange(existingRes, newRes ctlres.Resource) (Chan
 		return nil, err
 	}
 
-	return NewChange(existingRes, rebasedNewRes, newRes), nil
+	return NewChange(existingRes, rebasedNewRes, newRes, existingRes), nil
 }
 
 func (f ChangeFactory) NewResourceWithHistory(resource ctlres.Resource) ResourceWithHistory {

--- a/pkg/kapp/diff/change_precalculated.go
+++ b/pkg/kapp/diff/change_precalculated.go
@@ -51,9 +51,10 @@ func (d *ChangePrecalculated) NewOrExistingResource() ctlres.Resource {
 	panic("Not possible")
 }
 
-func (d *ChangePrecalculated) NewResource() ctlres.Resource      { return d.newRes }
-func (d *ChangePrecalculated) ExistingResource() ctlres.Resource { return d.existingRes }
-func (d *ChangePrecalculated) AppliedResource() ctlres.Resource  { return d.appliedRes }
+func (d *ChangePrecalculated) NewResource() ctlres.Resource             { return d.newRes }
+func (d *ChangePrecalculated) ExistingResource() ctlres.Resource        { return d.existingRes }
+func (d *ChangePrecalculated) AppliedResource() ctlres.Resource         { return d.appliedRes }
+func (d *ChangePrecalculated) ClusterOriginalResource() ctlres.Resource { return d.existingRes }
 
 func (d *ChangePrecalculated) Op() ChangeOp { return d.op }
 func (d *ChangePrecalculated) ConfigurableTextDiff() *ConfigurableTextDiff {

--- a/test/e2e/template_test.go
+++ b/test/e2e/template_test.go
@@ -207,8 +207,7 @@ data:
 -linesss-         secret:
 -linesss-           secretName: secret-ver-1
 -linesss-           secretName: secret-ver-2
--linesss- status:
--linesss-   availableReplicas: 1
+-linesss-
 `
 
 	name := "test-template"
@@ -275,6 +274,8 @@ func checkChangesOutput(t *testing.T, actualOutput, expectedOutput string) {
 	// Line numbers may change depending on what's being added to metadata section for example
 	// (metadata.managedFields was added and threw off all lines numbers)
 	diffLinesRegexp := regexp.MustCompile(`(?m:^\s*(\d{1,3}\s*|\d{1,3},\s*\d{1,3}|\d{1,3}) [\-+ ])`)
+	actualOutput = diffLinesRegexp.ReplaceAllString(actualOutput, "-linesss-")
+	diffLinesRegexp = regexp.MustCompile(` *\d{1,3}, *\d{1,3}`)
 	actualOutput = diffLinesRegexp.ReplaceAllString(actualOutput, "-linesss-")
 
 	// Useful for debugging:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Use diffAgainstLastAppliedFieldExclusionRules to exclude status field from diffs

Acceptance criteria:
- Deploy a service or a deployment with kapp, deploy them again and there should be no diff on the status
- Try updating the status field for a service or a deployment and the diff should be seen.
- If smart diff (using last applied annotation) is not used, diff in status will be seen.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #507 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
