### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
 linters:
   enable:
     - goheader
-    - golint
+    - revive
     - deadcode
     - unused
   disable-all: true

--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -71,7 +71,7 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
-	var exitCode float64 = 0
+	var exitCode float64
 	// TODO is there some order between apps?
 	for _, appGroupApp := range updatedApps {
 		err := o.deployApp(appGroupApp)

--- a/test/e2e/app_suffix_test.go
+++ b/test/e2e/app_suffix_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var yaml1 string = `
+var yaml1 = `
 ---
 apiVersion: v1
 kind: Service
@@ -34,7 +34,7 @@ data:
   key: value
 `
 
-var yaml2 string = `
+var yaml2 = `
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Replace golint with revive
Fixes the warning:
```bash
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
```

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
