### PR TITLE
change-rule to delete namespaced resources before namespace

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -614,6 +614,7 @@ changeRuleBindings:
 
 - rules:  
   - "delete after deleting change-groups.kapp.k14s.io/serviceaccount"
+  ignoreIfCyclical: true
   resourceMatchers:
   - andMatcher: {matchers: *namespaceMatchers}
 

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -577,7 +577,6 @@ changeRuleBindings:
 # Insert namespaces before all namespaced resources
 - rules:
   - "upsert after upserting change-groups.kapp.k14s.io/namespaces-{namespace}"
-  - "delete before deleting change-groups.kapp.k14s.io/namespaces-{namespace}"
   resourceMatchers:
   - andMatcher:
       matchers:
@@ -612,6 +611,11 @@ changeRuleBindings:
           matchers:
           - anyMatcher: {matchers: *serviceAccountMatchers}
           - anyMatcher: {matchers: *rbacMatchers}
+
+- rules:  
+  - "delete after deleting change-groups.kapp.k14s.io/serviceaccount"
+  resourceMatchers:
+  - andMatcher: {matchers: *namespaceMatchers}
 
 - rules:
   - "upsert after upserting change-groups.kapp.k14s.io/storage-class"

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -577,6 +577,7 @@ changeRuleBindings:
 # Insert namespaces before all namespaced resources
 - rules:
   - "upsert after upserting change-groups.kapp.k14s.io/namespaces-{namespace}"
+  - "delete before deleting change-groups.kapp.k14s.io/namespaces-{namespace}"
   resourceMatchers:
   - andMatcher:
       matchers:

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -612,11 +612,18 @@ changeRuleBindings:
           - anyMatcher: {matchers: *serviceAccountMatchers}
           - anyMatcher: {matchers: *rbacMatchers}
 
+# Delete serviceAccount (SA) before namespace (if serviceAccount is part of that namespace)
+# deletion of namespace before SA sometimes leads deletion of SA before 
+# the resources on which it is dependent on like kapp-controller-packageInstall
 - rules:  
-  - "delete after deleting change-groups.kapp.k14s.io/serviceaccount"
+  - "delete before deleting change-groups.kapp.k14s.io/namespaces-{namespace}"
   ignoreIfCyclical: true
   resourceMatchers:
-  - andMatcher: {matchers: *namespaceMatchers}
+  - andMatcher: 
+      matchers:
+      - notMatcher: {matcher: *disableDefaultChangeGroupAnnMatcher}
+      - anyMatcher: {matchers: *serviceAccountMatchers}
+
 
 - rules:
   - "upsert after upserting change-groups.kapp.k14s.io/storage-class"

--- a/pkg/kapp/diffgraph/change_graph_cf_for_k8s_test.go
+++ b/pkg/kapp/diffgraph/change_graph_cf_for_k8s_test.go
@@ -413,7 +413,6 @@ const (
 (delete) role/kpack-watcher-pod-logs-reader (rbac.authorization.k8s.io/v1) namespace: cf-workloads
 (delete) rolebinding/kpack-watcher-pod-logs-binding (rbac.authorization.k8s.io/v1) namespace: cf-workloads
 (delete) configmap/cloud-controller-ng-yaml (v1) namespace: cf-system
-(delete) namespace/cf-workloads-staging (v1) cluster
 (delete) deployment/capi-clock (apps/v1) namespace: cf-system
 (delete) deployment/capi-deployment-updater (apps/v1) namespace: cf-system
 (delete) configmap/nginx (v1) namespace: cf-system
@@ -446,7 +445,6 @@ const (
 (delete) networkpolicy/allow-app-ingress-from-ingressgateway (networking.k8s.io/v1) namespace: cf-workloads
 (delete) secret/app-registry-credentials (v1) namespace: cf-workloads
 (delete) secret/istio-ingressgateway-certs (v1) namespace: istio-system
-(delete) namespace/kpack (v1) cluster
 (delete) deployment/kpack-controller (apps/v1) namespace: kpack
 (delete) serviceaccount/controller (v1) namespace: kpack
 (delete) clusterrole/kpack-controller-admin (rbac.authorization.k8s.io/v1) cluster
@@ -479,7 +477,6 @@ const (
 (delete) secret/metric-proxy-cert (v1) namespace: cf-system
 (delete) secret/metric-proxy-ca (v1) namespace: cf-system
 (delete) deployment/metric-proxy (apps/v1) namespace: cf-system
-(delete) namespace/cf-blobstore (v1) cluster
 (delete) secret/cf-blobstore-minio (v1) namespace: cf-blobstore
 (delete) configmap/cf-blobstore-minio (v1) namespace: cf-blobstore
 (delete) persistentvolumeclaim/cf-blobstore-minio (v1) namespace: cf-blobstore
@@ -492,7 +489,6 @@ const (
 (delete) service/cfroutesync (v1) namespace: cf-system
 (delete) clusterrole/istio-reader-istio-system (rbac.authorization.k8s.io/v1) cluster
 (delete) clusterrolebinding/istio-reader-istio-system (rbac.authorization.k8s.io/v1) cluster
-(delete) namespace/istio-system (v1) cluster
 (delete) serviceaccount/istio-reader-service-account (v1) namespace: istio-system
 (delete) clusterrole/istio-citadel-istio-system (rbac.authorization.k8s.io/v1) cluster
 (delete) clusterrolebinding/istio-citadel-istio-system (rbac.authorization.k8s.io/v1) cluster
@@ -554,7 +550,6 @@ const (
 (delete) networkpolicy/mixer-network-policy (networking.k8s.io/v1) namespace: istio-system
 (delete) networkpolicy/sidecar-injector-network-policy (networking.k8s.io/v1) namespace: istio-system
 (delete) networkpolicy/ingressgateway-network-policy-pilot (networking.k8s.io/v1) namespace: istio-system
-(delete) namespace/metacontroller (v1) cluster
 (delete) serviceaccount/metacontroller (v1) namespace: metacontroller
 (delete) clusterrole/metacontroller (rbac.authorization.k8s.io/v1) cluster
 (delete) clusterrolebinding/metacontroller (rbac.authorization.k8s.io/v1) cluster
@@ -568,12 +563,18 @@ const (
 (delete) service/cf-db-postgresql-headless (v1) namespace: cf-db
 (delete) service/cf-db-postgresql (v1) namespace: cf-db
 (delete) statefulset/cf-db-postgresql (apps/v1) namespace: cf-db
-(delete) namespace/cf-system (v1) cluster
 (delete) configmap/uaa-config (v1) namespace: cf-system
 (delete) deployment/uaa (apps/v1) namespace: cf-system
 (delete) service/uaa (v1) namespace: cf-system
 (delete) serviceaccount/uaa (v1) namespace: cf-system
 (delete) secret/uaa-certs (v1) namespace: cf-system
+---
+(delete) namespace/cf-workloads-staging (v1) cluster
+(delete) namespace/kpack (v1) cluster
+(delete) namespace/cf-blobstore (v1) cluster
+(delete) namespace/istio-system (v1) cluster
+(delete) namespace/metacontroller (v1) cluster
+(delete) namespace/cf-system (v1) cluster
 (delete) namespace/cf-workloads (v1) cluster
 `
 )

--- a/pkg/kapp/diffgraph/change_graph_test.go
+++ b/pkg/kapp/diffgraph/change_graph_test.go
@@ -593,132 +593,27 @@ roleRef:
 func TestChangeGraphWithAppCR_RoleRoleBindingAndSA(t *testing.T) {
 	yaml := `
 apiVersion: v1
-kind: ServiceAccount
+kind: Namespace
 metadata:
-  name: default-ns-sa
-  namespace: default
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: default-ns-role
-  namespace: default
-rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: default-ns-role-binding
-  namespace: default
-subjects:
-- kind: ServiceAccount
-  name: default-ns-sa
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: default-ns-role
----
-apiVersion: kappctrl.k14s.io/v1alpha1
-kind: App
-metadata:
-  name: simple-app-cr
-  namespace: default
-spec:
-  serviceAccountName: default-ns-sa
-  fetch:
-  - git: {}
-  template:
-  - ytt: {}
-  deploy:
-  - kapp: {}
----
-apiVersion: packaging.carvel.dev/v1alpha1
-kind: PackageInstall
-metadata:
-  name: pkg-demo
-  namespace: default
-spec:
-  serviceAccountName: default-ns-sa
-  packageRef:
-    refName: simple-app.corp.com
-    versionSelection:
-      constraints: 1.0.0
-  values:
-  - secretRef:
-      name: pkg-demo-values
+  name: test1
 ---
 apiVersion: v1
-kind: Secret
+kind: ServiceAccount
 metadata:
-  name: pkg-demo-values
-  namespace: default
-stringData:
-  values.yml: |
-    ---
-    hello_msg: "to all my internet friends"
-`
-	_, conf, err := ctlconf.NewConfFromResourcesWithDefaults(nil)
-	require.NoErrorf(t, err, "Parsing conf defaults")
-
-	opts := buildGraphOpts{
-		resourcesBs:         yaml,
-		op:                  ctldgraph.ActualChangeOpUpsert,
-		changeGroupBindings: conf.ChangeGroupBindings(),
-		changeRuleBindings:  conf.ChangeRuleBindings(),
-	}
-
-	graph, err := buildChangeGraphWithOpts(opts, t)
-	require.NoErrorf(t, err, "Expected graph to build")
-
-	output := strings.TrimSpace(graph.PrintStr())
-	expectedOutput := strings.TrimSpace(`
-(upsert) serviceaccount/default-ns-sa (v1) namespace: default
-(upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-(upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
-  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-(upsert) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
-  (upsert) serviceaccount/default-ns-sa (v1) namespace: default
-  (upsert) secret/pkg-demo-values (v1) namespace: default
-  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
-    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-(upsert) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
-  (upsert) serviceaccount/default-ns-sa (v1) namespace: default
-  (upsert) secret/pkg-demo-values (v1) namespace: default
-  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
-    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-(upsert) secret/pkg-demo-values (v1) namespace: default
-`)
-	require.Equal(t, expectedOutput, output)
-
-	opts.op = ctldgraph.ActualChangeOpDelete
-	graph, err = buildChangeGraphWithOpts(opts, t)
-	require.NoErrorf(t, err, "Expected graph to build")
-
-	output = strings.TrimSpace(graph.PrintStr())
-	expectedOutput = strings.TrimSpace(`
-(delete) serviceaccount/default-ns-sa (v1) namespace: default
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
-(delete) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
-(delete) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
-(delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
-(delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
-(delete) secret/pkg-demo-values (v1) namespace: default
-`)
-	require.Equal(t, expectedOutput, output)
-}
-
-func TestChangeGraphWithNamespaceAndSA(t *testing.T) {
-	yaml := `
+  name: default-ns-sa1
+  namespace: test1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test2
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-ns-sa2
+  namespace: test2
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -798,7 +693,7 @@ stringData:
 
 	opts := buildGraphOpts{
 		resourcesBs:         yaml,
-		op:                  ctldgraph.ActualChangeOpDelete,
+		op:                  ctldgraph.ActualChangeOpUpsert,
 		changeGroupBindings: conf.ChangeGroupBindings(),
 		changeRuleBindings:  conf.ChangeRuleBindings(),
 	}
@@ -808,6 +703,78 @@ stringData:
 
 	output := strings.TrimSpace(graph.PrintStr())
 	expectedOutput := strings.TrimSpace(`
+(upsert) namespace/test1 (v1) cluster
+(upsert) serviceaccount/default-ns-sa1 (v1) namespace: test1
+  (upsert) namespace/test1 (v1) cluster
+(upsert) namespace/test2 (v1) cluster
+(upsert) serviceaccount/default-ns-sa2 (v1) namespace: test2
+  (upsert) namespace/test2 (v1) cluster
+(upsert) namespace/test (v1) cluster
+(upsert) serviceaccount/default-ns-sa (v1) namespace: test
+  (upsert) namespace/test (v1) cluster
+(upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
+  (upsert) namespace/test (v1) cluster
+(upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: test
+  (upsert) namespace/test (v1) cluster
+  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+(upsert) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
+  (upsert) namespace/test (v1) cluster
+  (upsert) serviceaccount/default-ns-sa1 (v1) namespace: test1
+    (upsert) namespace/test1 (v1) cluster
+  (upsert) serviceaccount/default-ns-sa2 (v1) namespace: test2
+    (upsert) namespace/test2 (v1) cluster
+  (upsert) serviceaccount/default-ns-sa (v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+  (upsert) secret/pkg-demo-values (v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
+      (upsert) namespace/test (v1) cluster
+(upsert) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
+  (upsert) namespace/test (v1) cluster
+  (upsert) serviceaccount/default-ns-sa1 (v1) namespace: test1
+    (upsert) namespace/test1 (v1) cluster
+  (upsert) serviceaccount/default-ns-sa2 (v1) namespace: test2
+    (upsert) namespace/test2 (v1) cluster
+  (upsert) serviceaccount/default-ns-sa (v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+  (upsert) secret/pkg-demo-values (v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: test
+    (upsert) namespace/test (v1) cluster
+    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
+      (upsert) namespace/test (v1) cluster
+(upsert) secret/pkg-demo-values (v1) namespace: test
+  (upsert) namespace/test (v1) cluster
+`)
+	require.Equal(t, expectedOutput, output)
+
+	opts.op = ctldgraph.ActualChangeOpDelete
+	graph, err = buildChangeGraphWithOpts(opts, t)
+	require.NoErrorf(t, err, "Expected graph to build")
+
+	output = strings.TrimSpace(graph.PrintStr())
+	expectedOutput = strings.TrimSpace(`
+  (delete) namespace/test1 (v1) cluster
+  (delete) serviceaccount/default-ns-sa1 (v1) namespace: test1
+    (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
+    (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
+(delete) serviceaccount/default-ns-sa1 (v1) namespace: test1
+  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
+  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
+(delete) namespace/test2 (v1) cluster
+  (delete) serviceaccount/default-ns-sa2 (v1) namespace: test2
+    (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
+    (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
+(delete) serviceaccount/default-ns-sa2 (v1) namespace: test2
+  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
+  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
 (delete) namespace/test (v1) cluster
   (delete) serviceaccount/default-ns-sa (v1) namespace: test
     (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test

--- a/pkg/kapp/diffgraph/change_graph_test.go
+++ b/pkg/kapp/diffgraph/change_graph_test.go
@@ -804,15 +804,6 @@ stringData:
   (delete) serviceaccount/default-ns-sa (v1) namespace: test
     (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
     (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
-  (delete) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: test
-    (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
-    (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
-  (delete) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: test
-    (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
-    (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
-  (delete) secret/pkg-demo-values (v1) namespace: test
 (delete) serviceaccount/default-ns-sa (v1) namespace: test
   (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: test
   (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: test

--- a/pkg/kapp/diffgraph/change_graph_test.go
+++ b/pkg/kapp/diffgraph/change_graph_test.go
@@ -709,7 +709,7 @@ stringData:
 	require.Equal(t, expectedOutput, output)
 }
 
-func TestChangeGraphWithNamespacedResourceDelete(t *testing.T) {
+func TestChangeGraphWithNamespaceAndSA(t *testing.T) {
 	yaml := `
 apiVersion: v1
 kind: Namespace

--- a/pkg/kapp/diffgraph/change_graph_test.go
+++ b/pkg/kapp/diffgraph/change_graph_test.go
@@ -596,11 +596,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-ns-sa
+  namespace: default
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-ns-role
+  namespace: default
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
@@ -610,6 +612,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-ns-role-binding
+  namespace: default
 subjects:
 - kind: ServiceAccount
   name: default-ns-sa
@@ -622,6 +625,7 @@ apiVersion: kappctrl.k14s.io/v1alpha1
 kind: App
 metadata:
   name: simple-app-cr
+  namespace: default
 spec:
   serviceAccountName: default-ns-sa
   fetch:
@@ -635,6 +639,7 @@ apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
   name: pkg-demo
+  namespace: default
 spec:
   serviceAccountName: default-ns-sa
   packageRef:
@@ -649,6 +654,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: pkg-demo-values
+  namespace: default
 stringData:
   values.yml: |
     ---
@@ -669,21 +675,23 @@ stringData:
 
 	output := strings.TrimSpace(graph.PrintStr())
 	expectedOutput := strings.TrimSpace(`
-(upsert) serviceaccount/default-ns-sa (v1) cluster
-(upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-(upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) cluster
-  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-(upsert) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) cluster
-  (upsert) serviceaccount/default-ns-sa (v1) cluster
-  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) cluster
-    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-(upsert) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) cluster
-  (upsert) serviceaccount/default-ns-sa (v1) cluster
-  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) cluster
-    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-(upsert) secret/pkg-demo-values (v1) cluster
+(upsert) serviceaccount/default-ns-sa (v1) namespace: default
+(upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+(upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
+  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+(upsert) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
+  (upsert) serviceaccount/default-ns-sa (v1) namespace: default
+  (upsert) secret/pkg-demo-values (v1) namespace: default
+  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
+    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+(upsert) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
+  (upsert) serviceaccount/default-ns-sa (v1) namespace: default
+  (upsert) secret/pkg-demo-values (v1) namespace: default
+  (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+  (upsert) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
+    (upsert) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+(upsert) secret/pkg-demo-values (v1) namespace: default
 `)
 	require.Equal(t, expectedOutput, output)
 
@@ -693,18 +701,18 @@ stringData:
 
 	output = strings.TrimSpace(graph.PrintStr())
 	expectedOutput = strings.TrimSpace(`
-(delete) serviceaccount/default-ns-sa (v1) cluster
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) cluster
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) cluster
-(delete) role/default-ns-role (rbac.authorization.k8s.io/v1) cluster
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) cluster
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) cluster
-(delete) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) cluster
-  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) cluster
-  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) cluster
-(delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) cluster
-(delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) cluster
-(delete) secret/pkg-demo-values (v1) cluster
+(delete) serviceaccount/default-ns-sa (v1) namespace: default
+  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
+  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
+(delete) role/default-ns-role (rbac.authorization.k8s.io/v1) namespace: default
+  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
+  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
+(delete) rolebinding/default-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: default
+  (delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
+  (delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
+(delete) app/simple-app-cr (kappctrl.k14s.io/v1alpha1) namespace: default
+(delete) packageinstall/pkg-demo (packaging.carvel.dev/v1alpha1) namespace: default
+(delete) secret/pkg-demo-values (v1) namespace: default
 `)
 	require.Equal(t, expectedOutput, output)
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes https://github.com/vmware-tanzu/carvel-kapp/issues/579

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
