### PR TITLE
Remove extra output in bash completion

### DIFF
--- a/cmd/kapp/kapp.go
+++ b/cmd/kapp/kapp.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cppforlife/cobrautil"
 	uierrs "github.com/cppforlife/go-cli-ui/errors"
 	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/vmware-tanzu/carvel-kapp/pkg/kapp/cmd"
@@ -45,6 +46,9 @@ func nonExitingMain() error {
 		return err
 	}
 
-	confUI.PrintLinef("Succeeded")
+	if !cobrautil.IsCobraInternalCommand(os.Args) {
+		confUI.PrintLinef("Succeeded")
+	}
+
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vmware-tanzu/carvel-kapp
 go 1.18
 
 require (
-	github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72
+	github.com/cppforlife/cobrautil v0.0.0-20220907150944-da5ee3a6ab1f
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835
 	github.com/cppforlife/go-cli-ui v0.0.0-20200716203538-1e47f820817f
 	github.com/cppforlife/go-patch v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,9 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72 h1:rPWcUBgMb1ox2eCohCuZ8gsZVe0aB5qBbYaBpdoxfCE=
 github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72/go.mod h1:2w+qxVu2KSGW78Ex/XaIqfh/OvBgjEsmN53S4T8vEyA=
+github.com/cppforlife/cobrautil v0.0.0-20220907150944-da5ee3a6ab1f h1:KkqeYFcNT2SHYUR5cGJ0YZoIZW12yFf36OBWFStufvk=
+github.com/cppforlife/cobrautil v0.0.0-20220907150944-da5ee3a6ab1f/go.mod h1:2w+qxVu2KSGW78Ex/XaIqfh/OvBgjEsmN53S4T8vEyA=
 github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835 h1:mYQweUIBD+TBRjIeQnJmXr0GSVMpI6O0takyb/aaOgo=
 github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835/go.mod h1:dYeVsKp1vvK8XjdTPR1gF+uk+9doxKeO3hqQTOCr7T4=
 github.com/cppforlife/go-cli-ui v0.0.0-20200505234325-512793797f05/go.mod h1:I0qrzCmuPWYI6kAOvkllYjaW2aovclWbJ96+v+YyHb0=

--- a/pkg/kapp/cmd/kapp.go
+++ b/pkg/kapp/cmd/kapp.go
@@ -66,7 +66,7 @@ func NewKappCmd(o *KappOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		// TODO bash completion
 	}
 
-	cmd.SetOutput(uiBlockWriter{o.ui}) // setting output for cmd.Help()
+	cmd.SetOut(uiBlockWriter{o.ui}) // setting output for cmd.Help()
 
 	cmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
 		cmdcore.AppHelpGroup,

--- a/vendor/github.com/cppforlife/cobrautil/misc.go
+++ b/vendor/github.com/cppforlife/cobrautil/misc.go
@@ -64,7 +64,7 @@ func ReconfigureCmdWithSubcmd(cmd *cobra.Command) {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
 		if !subcmd.Hidden {
-			strs = append(strs, subcmd.Use)
+			strs = append(strs, subcmd.Name())
 		}
 	}
 
@@ -87,7 +87,7 @@ func ShowSubcommands(cmd *cobra.Command, args []string) error {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
 		if !subcmd.Hidden {
-			strs = append(strs, subcmd.Use)
+			strs = append(strs, subcmd.Name())
 		}
 	}
 	return fmt.Errorf("Use one of available subcommands: %s", strings.Join(strs, ", "))
@@ -96,4 +96,23 @@ func ShowSubcommands(cmd *cobra.Command, args []string) error {
 func ShowHelp(cmd *cobra.Command, args []string) error {
 	cmd.Help()
 	return fmt.Errorf("Invalid command - see available commands/subcommands above")
+}
+
+func IsCobraInternalCommand(args []string) bool {
+	if len(args) > 1 {
+		cmdPathPieces := args[1:]
+
+		var cmdName string // first "non-flag" arguments
+		for _, arg := range cmdPathPieces {
+			if !strings.HasPrefix(arg, "-") {
+				cmdName = arg
+				break
+			}
+		}
+		switch cmdName {
+		case "help", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
+			return true
+		}
+	}
+	return false
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -26,7 +26,7 @@ github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 ## explicit
 github.com/PuerkitoBio/urlesc
-# github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72
+# github.com/cppforlife/cobrautil v0.0.0-20220907150944-da5ee3a6ab1f
 ## explicit
 github.com/cppforlife/cobrautil
 # github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Do not print Succeeded for help and hidden __complete command
- Use SetOut instead of deprecated SetOutput for setting output for help command.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #583 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
