### PR TITLE
Add flag to skip checking resources when fully delete app

### DIFF
--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -24,7 +24,7 @@ type App interface {
 
 	CreateOrUpdate(map[string]string, bool) error
 	Exists() (bool, string, error)
-	Delete() error
+	Delete(bool) error
 	Rename(string, string) error
 	RenamePrevApp(string, map[string]string, bool) error
 

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -47,10 +47,14 @@ func (a *LabeledApp) UpdateUsedGVsAndGKs([]schema.GroupVersion, []schema.GroupKi
 func (a *LabeledApp) CreateOrUpdate(labels map[string]string, isDiffRun bool) error { return nil }
 func (a *LabeledApp) Exists() (bool, string, error)                                 { return true, "", nil }
 
-func (a *LabeledApp) Delete() error {
+func (a *LabeledApp) Delete(checkResourcesDeleted bool) error {
 	labelSelector, err := a.LabelSelector()
 	if err != nil {
 		return err
+	}
+
+	if !checkResourcesDeleted {
+		return nil
 	}
 
 	rs, err := a.identifiedResources.List(labelSelector, nil, ctlres.IdentifiedResourcesListOpts{IgnoreCachedResTypes: true})

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -353,7 +353,7 @@ func (a *RecordedApp) Exists() (bool, string, error) {
 	return true, "", nil
 }
 
-func (a *RecordedApp) Delete() error {
+func (a *RecordedApp) Delete(checkResourcesDeleted bool) error {
 	app, err := a.labeledApp()
 	if err != nil {
 		return err
@@ -364,7 +364,7 @@ func (a *RecordedApp) Delete() error {
 		return fmt.Errorf("Deleting app changes: %w", err)
 	}
 
-	err = app.Delete()
+	err = app.Delete(checkResourcesDeleted)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/delete.go
+++ b/pkg/kapp/cmd/app/delete.go
@@ -29,6 +29,7 @@ type DeleteOptions struct {
 	ApplyFlags          ApplyFlags
 	ResourceTypesFlags  ResourceTypesFlags
 	PrevAppFlags        PrevAppFlags
+	DeleteFlags         DeleteFlags
 }
 
 type changesSummary struct {
@@ -56,6 +57,7 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 	o.ApplyFlags.SetWithDefaults("", ApplyFlagsDeleteDefaults, cmd)
 	o.ResourceTypesFlags.Set(cmd)
 	o.PrevAppFlags.Set(cmd)
+	o.DeleteFlags.Set(cmd)
 	return cmd
 }
 
@@ -157,7 +159,7 @@ func (o *DeleteOptions) Run() error {
 			return err
 		}
 		if shouldFullyDeleteApp {
-			return app.Delete()
+			return app.Delete(o.DeleteFlags.DisableCheckingResourceDeletion)
 		}
 		return nil
 	})

--- a/pkg/kapp/cmd/app/delete_flags.go
+++ b/pkg/kapp/cmd/app/delete_flags.go
@@ -1,0 +1,15 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+type DeleteFlags struct {
+	DisableCheckingResourceDeletion bool
+}
+
+func (s *DeleteFlags) Set(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&s.DisableCheckingResourceDeletion, "dangerous-disable-checking-resource-deletion",
+		false, "Skip checking resource deletion when fully deleting app")
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add flag to skip checking resources when fully deletes app. 

#### Which issue(s) this PR fixes:

Fixes #577 

#### Does this PR introduce a user-facing change?

```release-note
Add `--dangerous-disable-checking-app-deletion` flag to  disable checking resources when fully deletes app #594
```
#### Additional Notes for your reviewer:

- Relevant carvel.dev docs will be added as soon as possible
- I'm not sure about the impact of remaining resources on test envrionment, so I didn't write e2e test for this flag

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
