### PR TITLE
tell the user the file doesnt exist if the file doesnt exist

### DIFF
--- a/pkg/kapp/resources/file_resources.go
+++ b/pkg/kapp/resources/file_resources.go
@@ -32,7 +32,7 @@ func NewFileResources(file string) ([]FileResource, error) {
 	default:
 		fileInfo, err := os.Stat(file)
 		if err != nil {
-			return nil, fmt.Errorf("Checking file '%s'", file)
+			return nil, fmt.Errorf("Checking file: %v", err)
 		}
 
 		if fileInfo.IsDir() {


### PR DESCRIPTION
before this change:

`kapp deploy -a myApp -f typo-in-filebame.yml` =>
```
 kapp: Error: Checking file 'typo-in-filebame.yml.yml'
 ```
 
 and Imma be real with you,  I thought that meant my yaml was malformed or something, so I spent several minutes editing the file trying to fix don quixote's yaml formatting errors, rerunning kapp and getting the exact same error,  until i realized I was in the wrong directory in the first place.
 
 
 After this change: 
 
 ```
 kapp: Error: Checking file: stat typo-in-filebame.yml.yml: no such file or directory
 ```
 
 the magic words there are "no such file or directory" which is _exactly_ what I expect my *nix flavored OS to tell me when a file can't be found.   including the word "stat" in there is optional but in this case it's the path of least resistance. 
 