### PR TITLE
Remove unknown fields from CR in warnings test

### DIFF
--- a/test/e2e/warnings_test.go
+++ b/test/e2e/warnings_test.go
@@ -69,9 +69,6 @@ apiVersion: "stable.example.com/v1alpha1"
 kind: CronTab
 metadata:
   name: <cr-name>
-spec:
-  cronSpec: "* * * * */5"
-  image: my-awesome-cron-image
 `
 
 	logger.Section("deploying crd with deprecated version", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
With kubernetes 1.25+ we now get warnings for unknown fields, which caused the test to fail.
We could have also added definition of spec in the CRD, but that didn't seem necessary for this test so I went ahead with removing the spec from cr.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

