### PR TITLE
Update default PVC rebase rule to account for migration

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -78,6 +78,7 @@ rebaseRules:
 - paths:
   - [metadata, annotations, pv.kubernetes.io/bind-completed]
   - [metadata, annotations, pv.kubernetes.io/bound-by-controller]
+  - [metadata, annotations, pv.kubernetes.io/migrated-to]
   - [metadata, annotations, volume.beta.kubernetes.io/storage-provisioner]
   - [spec, storageClassName]
   - [spec, volumeMode]


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Adds a rebase rule to copy an annotation that indicates that a PVC has been [migrated to CSI volumes](https://kubernetes.io/blog/2021/12/10/storage-in-tree-to-csi-migration-status-update/).

Adds an additional
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #605 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
