### PR TITLE
Include default template rules for packaging resources

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -398,6 +398,22 @@ templateRules:
       resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}
 
+    - path: [spec, fetch, {allIndexes: true}, inline, pathsFrom, {allIndexes: true}, configMapRef]
+      resourceMatchers: &appMatchers
+      - apiVersionKindMatcher: {apiVersion: kappctrl.k14s.io/v1alpha1, kind: App}
+    - path: [spec, template, {allIndexes: true}, ytt, inline, pathsFrom, {allIndexes: true}, configMapRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, ytt, valuesFrom, {allIndexes: true}, configMapRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, helmTemplate, valuesFrom, {allIndexes: true}, configMapRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, cue, valuesFrom, {allIndexes: true}, configMapRef]
+      resourceMatchers: *appMatchers
+
+    - path: [spec, fetch, inline, pathsFrom, {allIndexes: true}, configMapRef]
+      resourceMatchers: &packageRepositoryMatchers
+      - apiVersionKindMatcher: {apiVersion: packaging.carvel.dev/v1alpha1, kind: PackageRepository}
+
 - resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: v1, kind: Secret}
   affectedResources:
@@ -447,6 +463,38 @@ templateRules:
     - path: [secrets, {allIndexes: true}]
       resourceMatchers:
       - apiVersionKindMatcher: {apiVersion: v1, kind: ServiceAccount}
+
+    - path: [spec, cluster, kubeconfigSecretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, fetch, {allIndexes: true}, inline, pathsFrom, {allIndexes: true}, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, fetch, {allIndexes: true}, imgpkgBundle, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, fetch, {allIndexes: true}, http, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, fetch, {allIndexes: true}, git, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, fetch, {allIndexes: true}, helmChart, repository, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, ytt, inline, pathsFrom, {allIndexes: true}, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, ytt, valuesFrom, {allIndexes: true}, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, helmTemplate, valuesFrom, {allIndexes: true}, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, cue, valuesFrom, {allIndexes: true}, secretRef]
+      resourceMatchers: *appMatchers
+    - path: [spec, template, {allIndexes: true}, sops, pgp, privateKeySecretRef]
+      resourceMatchers: *appMatchers
+
+    - path: [spec, values, {allIndexes: true}, secretRef]
+      resourceMatchers: &packageInstallMatchers
+      - apiVersionKindMatcher: {apiVersion: packaging.carvel.dev/v1alpha1, kind: PackageInstall}
+    - path: [spec, cluster, kubeconfigSecretRef]
+      resourceMatchers: *packageInstallMatchers
+
+    - path: [spec, fetch, inline, pathsFrom, {allIndexes: true}, secretRef]
+      resourceMatchers: *packageRepositoryMatchers
 
 changeGroupBindings:
 - name: change-groups.kapp.k14s.io/crds
@@ -524,12 +572,10 @@ changeGroupBindings:
   - apiVersionKindMatcher: {kind: ServiceAccount, apiVersion: v1}
 
 - name: change-groups.kapp.k14s.io/kapp-controller-app
-  resourceMatchers:
-  - apiVersionKindMatcher: {kind: App, apiVersion: kappctrl.k14s.io/v1alpha1}
+  resourceMatchers: *appMatchers
 
 - name: change-groups.kapp.k14s.io/kapp-controller-packageinstall
-  resourceMatchers:
-  - apiVersionKindMatcher: {kind: PackageInstall, apiVersion: packaging.carvel.dev/v1alpha1}
+  resourceMatchers: *packageInstallMatchers
 
 changeRuleBindings:
 # Insert CRDs before all CRs

--- a/pkg/kapp/config/default_test.go
+++ b/pkg/kapp/config/default_test.go
@@ -1,0 +1,306 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/carvel-kapp/pkg/kapp/config"
+	ctldiff "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/diff"
+	ctlres "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resources"
+	"strings"
+	"testing"
+)
+
+func TestDefaultTemplateRules(t *testing.T) {
+	_, defaultConfig, err := config.NewConfFromResourcesWithDefaults([]ctlres.Resource{})
+	require.NoError(t, err)
+	changeFactory := ctldiff.NewChangeFactory(defaultConfig.RebaseMods(), defaultConfig.DiffAgainstLastAppliedFieldExclusionMods())
+
+	testCases := []struct {
+		description  string
+		newYAML      []byte
+		expectedDiff string
+	}{
+		{
+			description: `kappctrl.k14s.io/v1alpha1/App`,
+			newYAML: []byte(`
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  annotations:
+    kapp.k14s.io/versioned: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  annotations:
+    kapp.k14s.io/versioned: ""
+---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: test
+spec:
+  cluster:
+    kubeconfigSecretRef:
+      name: test-secret
+  fetch:
+    - inline:
+        pathsFrom:
+          - secretRef:
+              name: test-secret
+          - configMapRef:
+              name: test-configmap
+    - imgpkgBundle:
+        secretRef:
+          name: test-secret
+    - http:
+        secretRef:
+          name: test-secret
+    - git:
+        secretRef:
+          name: test-secret
+    - helmChart:
+        repository:
+          secretRef:
+            name: test-secret
+  template:
+    - ytt:
+        inline:
+          pathsFrom:
+            - secretRef:
+                name: test-secret
+            - configMapRef:
+                name: test-configmap
+        valuesFrom:
+          - secretRef:
+              name: test-secret
+          - configMapRef:
+              name: test-configmap
+    - helmTemplate:
+        valuesFrom:
+          - secretRef:
+              name: test-secret
+          - configMapRef:
+              name: test-configmap
+    - cue:
+        valuesFrom:
+          - secretRef:
+              name: test-secret
+          - configMapRef:
+              name: test-configmap
+    - sops:
+        pgp:
+          privateKeySecretRef:
+            name: test-secret
+`),
+			expectedDiff: strings.TrimLeft(`
+  0,  0 + apiVersion: v1
+  0,  1 + kind: ConfigMap
+  0,  2 + metadata:
+  0,  3 +   annotations:
+  0,  4 +     kapp.k14s.io/versioned: ""
+  0,  5 +   name: test-configmap-ver-1
+  0,  6 + 
+  0,  0 + apiVersion: v1
+  0,  1 + kind: Secret
+  0,  2 + metadata:
+  0,  3 +   annotations:
+  0,  4 +     kapp.k14s.io/versioned: ""
+  0,  5 +   name: test-secret-ver-1
+  0,  6 + 
+  0,  0 + apiVersion: kappctrl.k14s.io/v1alpha1
+  0,  1 + kind: App
+  0,  2 + metadata:
+  0,  3 +   name: test
+  0,  4 + spec:
+  0,  5 +   cluster:
+  0,  6 +     kubeconfigSecretRef:
+  0,  7 +       name: test-secret-ver-1
+  0,  8 +   fetch:
+  0,  9 +   - inline:
+  0, 10 +       pathsFrom:
+  0, 11 +       - secretRef:
+  0, 12 +           name: test-secret-ver-1
+  0, 13 +       - configMapRef:
+  0, 14 +           name: test-configmap-ver-1
+  0, 15 +   - imgpkgBundle:
+  0, 16 +       secretRef:
+  0, 17 +         name: test-secret-ver-1
+  0, 18 +   - http:
+  0, 19 +       secretRef:
+  0, 20 +         name: test-secret-ver-1
+  0, 21 +   - git:
+  0, 22 +       secretRef:
+  0, 23 +         name: test-secret-ver-1
+  0, 24 +   - helmChart:
+  0, 25 +       repository:
+  0, 26 +         secretRef:
+  0, 27 +           name: test-secret-ver-1
+  0, 28 +   template:
+  0, 29 +   - ytt:
+  0, 30 +       inline:
+  0, 31 +         pathsFrom:
+  0, 32 +         - secretRef:
+  0, 33 +             name: test-secret-ver-1
+  0, 34 +         - configMapRef:
+  0, 35 +             name: test-configmap-ver-1
+  0, 36 +       valuesFrom:
+  0, 37 +       - secretRef:
+  0, 38 +           name: test-secret-ver-1
+  0, 39 +       - configMapRef:
+  0, 40 +           name: test-configmap-ver-1
+  0, 41 +   - helmTemplate:
+  0, 42 +       valuesFrom:
+  0, 43 +       - secretRef:
+  0, 44 +           name: test-secret-ver-1
+  0, 45 +       - configMapRef:
+  0, 46 +           name: test-configmap-ver-1
+  0, 47 +   - cue:
+  0, 48 +       valuesFrom:
+  0, 49 +       - secretRef:
+  0, 50 +           name: test-secret-ver-1
+  0, 51 +       - configMapRef:
+  0, 52 +           name: test-configmap-ver-1
+  0, 53 +   - sops:
+  0, 54 +       pgp:
+  0, 55 +         privateKeySecretRef:
+  0, 56 +           name: test-secret-ver-1
+  0, 57 + 
+`, "\n"),
+		},
+		{
+			description: `packaging.carvel.dev/v1alpha1/PackageRepository`,
+			newYAML: []byte(`
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  annotations:
+    kapp.k14s.io/versioned: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  annotations:
+    kapp.k14s.io/versioned: ""
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: test
+spec:
+  fetch:
+    inline:
+      pathsFrom:
+      - configMapRef:
+          name: test-configmap
+      - secretRef:
+          name: test-secret
+`),
+			expectedDiff: strings.TrimLeft(`
+  0,  0 + apiVersion: v1
+  0,  1 + kind: ConfigMap
+  0,  2 + metadata:
+  0,  3 +   annotations:
+  0,  4 +     kapp.k14s.io/versioned: ""
+  0,  5 +   name: test-configmap-ver-1
+  0,  6 + 
+  0,  0 + apiVersion: v1
+  0,  1 + kind: Secret
+  0,  2 + metadata:
+  0,  3 +   annotations:
+  0,  4 +     kapp.k14s.io/versioned: ""
+  0,  5 +   name: test-secret-ver-1
+  0,  6 + 
+  0,  0 + apiVersion: packaging.carvel.dev/v1alpha1
+  0,  1 + kind: PackageRepository
+  0,  2 + metadata:
+  0,  3 +   name: test
+  0,  4 + spec:
+  0,  5 +   fetch:
+  0,  6 +     inline:
+  0,  7 +       pathsFrom:
+  0,  8 +       - configMapRef:
+  0,  9 +           name: test-configmap-ver-1
+  0, 10 +       - secretRef:
+  0, 11 +           name: test-secret-ver-1
+  0, 12 + 
+`, "\n"),
+		},
+		{
+			description: `packaging.carvel.dev/v1alpha1/PackageInstall`,
+			newYAML: []byte(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  annotations:
+    kapp.k14s.io/versioned: ""
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: test
+spec:
+  values:
+  - secretRef:
+      name: test-secret
+  cluster:
+    kubeconfigSecretRef:
+      name: test-secret
+`),
+			expectedDiff: strings.TrimLeft(`
+  0,  0 + apiVersion: v1
+  0,  1 + kind: Secret
+  0,  2 + metadata:
+  0,  3 +   annotations:
+  0,  4 +     kapp.k14s.io/versioned: ""
+  0,  5 +   name: test-secret-ver-1
+  0,  6 + 
+  0,  0 + apiVersion: packaging.carvel.dev/v1alpha1
+  0,  1 + kind: PackageInstall
+  0,  2 + metadata:
+  0,  3 +   name: test
+  0,  4 + spec:
+  0,  5 +   cluster:
+  0,  6 +     kubeconfigSecretRef:
+  0,  7 +       name: test-secret-ver-1
+  0,  8 +   values:
+  0,  9 +   - secretRef:
+  0, 10 +       name: test-secret-ver-1
+  0, 11 + 
+`, "\n"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Deserialize YAML into resources
+		docs, err := ctlres.NewYAMLFile(ctlres.NewBytesSource(testCase.newYAML)).Docs()
+		require.NoError(t, err)
+		var newResources []ctlres.Resource
+		for _, doc := range docs {
+			bytes, err := ctlres.NewResourcesFromBytes(doc)
+			require.NoError(t, err)
+			newResources = append(newResources, bytes...)
+		}
+
+		// Calculate changes with default template rules
+		changes, err := ctldiff.NewChangeSetWithVersionedRs([]ctlres.Resource{}, newResources, defaultConfig.TemplateRules(), ctldiff.ChangeSetOpts{}, changeFactory).Calculate()
+		require.NoError(t, err)
+
+		// Compare against expected diff
+		var diff strings.Builder
+		for _, change := range changes {
+			diff.WriteString(change.ConfigurableTextDiff().Full().FullString())
+		}
+		require.Equal(t, testCase.expectedDiff, diff.String())
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This PR include default `templateRules` for _kapp-controller_'s packaging resources; `PackageRepository`, `PackageInstall` and `App`. Since _kapp_ and _kapp-controller_ are companions it seems helpful.

In particular, the following `templateRules` are added to the defaults:

* `PackageRepository` (according to [spec](https://carvel.dev/kapp-controller/docs/v0.40.0/packaging/#package-repository))
  * `.spec.fetch.inline.pathsFrom[].secretRef`
  * `.spec.fetch.inline.pathsFrom[].configMapRef`

* `PackageInstall` (according to [spec](https://carvel.dev/kapp-controller/docs/v0.40.0/packaging/#package-install))

  * `.spec.values[].secretRef`
  * `.spec.cluster.kubeconfigSecretRef`

* `App` (according to [spec](https://carvel.dev/kapp-controller/docs/v0.40.0/app-spec/))

  * `.spec.cluster.kubeconfigSecretRef`
  * `.spec.fetch[].inline.pathsFrom[].secretRef`
  * `.spec.fetch[].inline.pathsFrom[].configMapRef`
  * `.spec.fetch[].imgpkgBundle.secretRef`
  * `.spec.fetch[].http.secretRef`
  * `.spec.fetch[].git.secretRef`
  * `.spec.fetch[].helmChart.repository.secretRef`
  * `.spec.template[].ytt.inline.pathsFrom[].secretRef`
  * `.spec.template[].ytt.inline.pathsFrom[].configMapRef`
  * `.spec.template[].ytt.valuesFrom[].secretRef`
  * `.spec.template[].ytt.valuesFrom[].configMapRef`
  * `.spec.template[].helmTemplate.valuesFrom[].secretRef`
  * `.spec.template[].helmTemplate.valuesFrom[].configMapRef`
  * `.spec.template[].cue.valuesFrom[].secretRef`
  * `.spec.template[].sops.pgp.privateKeySecretRef`

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #596

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Include default template rules for _kapp-controller_'s `PackageRepository`, `PackageInstall` and `App` resources.
```

#### Questions for the maintainers:

* Is this change wanted at all? From what I can tell, additional template rules are a non-invasive / non-breaking change. However, I can't intuit if this could have unwanted effects on _kapp-controller_.

* After studying the code base, I think to understand that there are no (focused) tests for the default config in general and its template rules in particular. However, this change needs to be tested. Before I invest, I would love to know the maintainers recommendation for covering this. There are unit tests for versioned resources and e2e tests. I imagine tests for the default config to sit in between them, e.g. maybe a `default_test.go` which contains `TestDefaultTemplateRules_{PackageRepository, PackageInstall, App}`.

  In the meantime, I have _manually_ tested the new rules. See details in comment.

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
