### PR TITLE
Skip gatekeeper in test-external.sh

### DIFF
--- a/hack/test-external.sh
+++ b/hack/test-external.sh
@@ -19,8 +19,9 @@ time kapp delete -y -a cert-manager
 
 # TODO Add cf-for-k8s-v5.4.3
 
-time kapp deploy -y -a gk -f examples/gatekeeper-v3.7.0/config.yml
-time kapp delete -y -a gk
+# TODO Add gatekeeper 3.10.0 when it's available
+# time kapp deploy -y -a gk -f examples/gatekeeper-v3.7.0/config.yml
+# time kapp delete -y -a gk
 
 time kapp deploy -y -a pinniped -f examples/pinniped-v0.13.0/
 time kapp delete -y -a pinniped


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Skip gatekeeper in test-external.sh
- gatekeeper uses PodSecurityPolicy which is removed in kubernetes 1.25. We can add gatekeeper v3.10.0 when it's available (as it migrates away from PodSecurityPolicy)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```
