### PR TITLE
Skip istio in test-external.sh

### DIFF
--- a/hack/test-external.sh
+++ b/hack/test-external.sh
@@ -7,8 +7,9 @@ minikube tunnel &> /dev/null &
 time kapp app-group deploy -y -g gitops -d examples/gitops/
 time kapp app-group delete -y -g gitops
 
-time kapp deploy -y -a istio -f examples/istio-v1.12.2/
-time kapp delete -y -a istio
+# TODO Add new istio version of istio supporting k8s 1.25 when it's available
+# time kapp deploy -y -a istio -f examples/istio-v1.12.2/
+# time kapp delete -y -a istio
 
 time kapp deploy -y -a cert-manager -f examples/cert-manager-v1.6.1/
 time kapp delete -y -a cert-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Skip istio in test-external.sh
- istio uses v1beta1/PodDisruptionBudget which is removed in kubernetes 1.25. We can add a new version of istio which supports kubernetes 1.25.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
