### PR TITLE
Set default for Kubernetes service port

### DIFF
--- a/pkg/kapp/cmd/core/config_factory.go
+++ b/pkg/kapp/cmd/core/config_factory.go
@@ -113,7 +113,12 @@ func (f *ConfigFactoryImpl) clientConfig() (bool, clientcmd.ClientConfig, error)
 	}
 
 	if len(configYAML) > 0 {
-		envHostPort := net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
+		// If it is not provided, we default the Kubernetes service port to 443
+		kubernetesServicePort, ok := os.LookupEnv("KUBERNETES_SERVICE_PORT")
+		if !ok {
+			kubernetesServicePort = "443"
+		}
+		envHostPort := net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), kubernetesServicePort)
 		configYAML = strings.ReplaceAll(configYAML, "${KAPP_KUBERNETES_SERVICE_HOST_PORT}", envHostPort)
 		config, err := clientcmd.NewClientConfigFromBytes([]byte(configYAML))
 		return true, config, err

--- a/pkg/kapp/cmd/core/config_factory.go
+++ b/pkg/kapp/cmd/core/config_factory.go
@@ -113,12 +113,13 @@ func (f *ConfigFactoryImpl) clientConfig() (bool, clientcmd.ClientConfig, error)
 	}
 
 	if len(configYAML) > 0 {
-		// If it is not provided, we default the Kubernetes service port to 443
-		kubernetesServicePort, ok := os.LookupEnv("KUBERNETES_SERVICE_PORT")
-		if !ok {
-			kubernetesServicePort = "443"
+		kubernetesHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+		kubernetesServicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
+		envHostPort := net.JoinHostPort(kubernetesHost, kubernetesServicePort)
+		if kubernetesServicePort == "" {
+			// client-go will manually add the port based on http/https
+			envHostPort = kubernetesHost
 		}
-		envHostPort := net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), kubernetesServicePort)
 		configYAML = strings.ReplaceAll(configYAML, "${KAPP_KUBERNETES_SERVICE_HOST_PORT}", envHostPort)
 		config, err := clientcmd.NewClientConfigFromBytes([]byte(configYAML))
 		return true, config, err


### PR DESCRIPTION
Signed-off-by: Víctor Martínez Bevià <vicmarbev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

Sets a default for the Kubernetes service port, so it does not fail when it is not provided.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #615 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
