### PR TITLE
updated wait-check-interval default value to 3s

### DIFF
--- a/pkg/kapp/cmd/app/apply_flags.go
+++ b/pkg/kapp/cmd/app/apply_flags.go
@@ -60,7 +60,7 @@ func (s *ApplyFlags) SetWithDefaults(prefix string, defaults ApplyFlags, cmd *co
 	cmd.Flags().DurationVar(&s.WaitingChangesOpts.ResourceTimeout, prefix+"wait-resource-timeout",
 		mustParseDuration("0s"), "Maximum amount of time to wait for a resource in wait phase (0s means no timeout)")
 	cmd.Flags().DurationVar(&s.WaitingChangesOpts.CheckInterval, prefix+"wait-check-interval",
-		mustParseDuration("1s"), "Amount of time to sleep between checks while waiting")
+		mustParseDuration("3s"), "Amount of time to sleep between checks while waiting")
 	cmd.Flags().IntVar(&s.WaitingChangesOpts.Concurrency, prefix+"wait-concurrency",
 		5, "Maximum number of concurrent wait operations")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
updated wait-check-interval default value to 3s
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Default wait-check-interval duration is now increased to 3s from 1s.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
