### PR TITLE
Experimental: Use generated app label as app change label value

### DIFF
--- a/pkg/kapp/app/recorded_app_changes.go
+++ b/pkg/kapp/app/recorded_app_changes.go
@@ -18,18 +18,20 @@ import (
 const (
 	isChangeLabelKey   = "kapp.k14s.io/is-app-change"
 	isChangeLabelValue = ""
-	changeLabelKey     = "kapp.k14s.io/app-change-app" // holds app name
+	changeLabelKey     = "kapp.k14s.io/app-change-app" // holds app label
 )
 
 type RecordedAppChanges struct {
 	nsName  string
 	appName string
 
+	changeLabelValue string
+
 	coreClient kubernetes.Interface
 }
 
-func NewRecordedAppChanges(nsName, appName string, coreClient kubernetes.Interface) RecordedAppChanges {
-	return RecordedAppChanges{nsName, appName, coreClient}
+func NewRecordedAppChanges(nsName, appName, changeLabelValue string, coreClient kubernetes.Interface) RecordedAppChanges {
+	return RecordedAppChanges{nsName, appName, changeLabelValue, coreClient}
 }
 
 func (a RecordedAppChanges) List() ([]Change, error) {
@@ -38,7 +40,7 @@ func (a RecordedAppChanges) List() ([]Change, error) {
 	listOpts := metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
 			isChangeLabelKey: isChangeLabelValue,
-			changeLabelKey:   a.appName,
+			changeLabelKey:   a.changeLabelValue,
 		}).String(),
 	}
 
@@ -70,7 +72,7 @@ func (a RecordedAppChanges) DeleteAll() error {
 	listOpts := metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
 			isChangeLabelKey: isChangeLabelValue,
-			changeLabelKey:   a.appName,
+			changeLabelKey:   a.changeLabelValue,
 		}).String(),
 	}
 
@@ -102,7 +104,7 @@ func (a RecordedAppChanges) Begin(meta ChangeMeta) (*ChangeImpl, error) {
 			Namespace:    a.nsName,
 			Labels: map[string]string{
 				isChangeLabelKey: isChangeLabelValue,
-				changeLabelKey:   a.appName,
+				changeLabelKey:   a.changeLabelValue,
 			},
 		},
 		Data: newMeta.AsData(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Use generated app label as app change label value by setting Breaking change!
This change is not backward compatible

Example scenario:
```
Existing: app deployed with old kapp
- app changes will be created with new label value (old app changes will be ignored, we can change this behaviour at the cost of an extra api call)
- Backward incompatibility: Switch to old version of kapp. Notice that it's not able to list the new app changes (there's nothing we can do about it).
```


#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #646 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
