### PR TITLE
Avoid listing labeled resources for newly created app

### DIFF
--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -22,7 +22,7 @@ type App interface {
 	UsedGKs() (*[]schema.GroupKind, error)
 	UpdateUsedGVsAndGKs([]schema.GroupVersion, []schema.GroupKind) error
 
-	CreateOrUpdate(map[string]string, bool) error
+	CreateOrUpdate(map[string]string, bool) (bool, error)
 	Exists() (bool, string, error)
 	Delete() error
 	Rename(string, string) error

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -44,8 +44,10 @@ func (a *LabeledApp) UsedGVs() ([]schema.GroupVersion, error)                   
 func (a *LabeledApp) UsedGKs() (*[]schema.GroupKind, error)                               { return nil, nil }
 func (a *LabeledApp) UpdateUsedGVsAndGKs([]schema.GroupVersion, []schema.GroupKind) error { return nil }
 
-func (a *LabeledApp) CreateOrUpdate(labels map[string]string, isDiffRun bool) error { return nil }
-func (a *LabeledApp) Exists() (bool, string, error)                                 { return true, "", nil }
+func (a *LabeledApp) CreateOrUpdate(labels map[string]string, isDiffRun bool) (bool, error) {
+	return false, nil
+}
+func (a *LabeledApp) Exists() (bool, string, error) { return true, "", nil }
 
 func (a *LabeledApp) Delete() error {
 	labelSelector, err := a.LabelSelector()

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -127,32 +127,32 @@ func (a *RecordedApp) UpdateUsedGVsAndGKs(gvs []schema.GroupVersion, gks []schem
 	})
 }
 
-func (a *RecordedApp) CreateOrUpdate(labels map[string]string, isDiffRun bool) error {
+func (a *RecordedApp) CreateOrUpdate(labels map[string]string, isDiffRun bool) (bool, error) {
 	defer a.logger.DebugFunc("CreateOrUpdate").Finish()
 
 	app, foundMigratedApp, err := a.find(a.fqName())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if foundMigratedApp {
 		a.isMigrated = true
-		return a.updateApp(app, labels)
+		return false, a.updateApp(app, labels)
 	}
 
 	app, foundNonMigratedApp, err := a.find(a.name)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if foundNonMigratedApp {
 		if a.isMigrationEnabled() {
-			return a.migrate(app, labels, a.fqName())
+			return false, a.migrate(app, labels, a.fqName())
 		}
-		return a.updateApp(app, labels)
+		return false, a.updateApp(app, labels)
 	}
 
-	return a.create(labels, isDiffRun)
+	return true, a.create(labels, isDiffRun)
 }
 
 func (a *RecordedApp) find(name string) (*corev1.ConfigMap, bool, error) {

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -92,6 +92,7 @@ func NewDeployCmd(o *DeployOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 }
 
 func (o *DeployOptions) Run() error {
+	var newApp bool
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
 	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
@@ -107,7 +108,7 @@ func (o *DeployOptions) Run() error {
 	if o.PrevAppFlags.PrevAppName != "" {
 		err = app.RenamePrevApp(o.PrevAppFlags.PrevAppName, appLabels, o.DiffFlags.Run)
 	} else {
-		err = app.CreateOrUpdate(appLabels, o.DiffFlags.Run)
+		newApp, err = app.CreateOrUpdate(appLabels, o.DiffFlags.Run)
 	}
 
 	if err != nil {
@@ -158,7 +159,7 @@ func (o *DeployOptions) Run() error {
 	}
 
 	existingResources, existingPodRs, err := o.existingResources(
-		newResources, labeledResources, resourceFilter, supportObjs.Apps, usedGKs, append(meta.LastChange.Namespaces, nsNames...))
+		newResources, labeledResources, resourceFilter, supportObjs.Apps, usedGKs, append(meta.LastChange.Namespaces, nsNames...), newApp)
 	if err != nil {
 		return err
 	}
@@ -352,7 +353,7 @@ func (o *DeployOptions) newResourcesFromFiles() ([]ctlres.Resource, error) {
 
 func (o *DeployOptions) existingResources(newResources []ctlres.Resource,
 	labeledResources *ctlres.LabeledResources, resourceFilter ctlres.ResourceFilter,
-	apps ctlapp.Apps, usedGKs []schema.GroupKind, resourceNamespaces []string) ([]ctlres.Resource, []ctlres.Resource, error) {
+	apps ctlapp.Apps, usedGKs []schema.GroupKind, resourceNamespaces []string, newApp bool) ([]ctlres.Resource, []ctlres.Resource, error) {
 
 	labelErrorResolutionFunc := func(key string, val string) string {
 		items, _ := apps.List(nil)
@@ -378,6 +379,7 @@ func (o *DeployOptions) existingResources(newResources []ctlres.Resource,
 		IdentifiedResourcesListOpts: ctlres.IdentifiedResourcesListOpts{
 			GKsScope:           usedGKs,
 			ResourceNamespaces: resourceNamespaces,
+			NewApp:             newApp,
 		},
 	}
 

--- a/pkg/kapp/resources/identified_resources_list.go
+++ b/pkg/kapp/resources/identified_resources_list.go
@@ -15,7 +15,6 @@ type IdentifiedResourcesListOpts struct {
 	IgnoreCachedResTypes bool
 	GKsScope             []schema.GroupKind
 	ResourceNamespaces   []string
-	NewApp               bool
 }
 
 func (r IdentifiedResources) List(labelSelector labels.Selector, resRefs []ResourceRef, opts IdentifiedResourcesListOpts) ([]Resource, error) {
@@ -24,11 +23,6 @@ func (r IdentifiedResources) List(labelSelector labels.Selector, resRefs []Resou
 	resTypes, err := r.resourceTypes.All(opts.IgnoreCachedResTypes)
 	if err != nil {
 		return nil, err
-	}
-
-	// avoid listing labeled resources for newly created app
-	if opts.NewApp {
-		return nil, nil
 	}
 
 	// TODO non-listable types

--- a/pkg/kapp/resources/identified_resources_list.go
+++ b/pkg/kapp/resources/identified_resources_list.go
@@ -15,6 +15,7 @@ type IdentifiedResourcesListOpts struct {
 	IgnoreCachedResTypes bool
 	GKsScope             []schema.GroupKind
 	ResourceNamespaces   []string
+	NewApp               bool
 }
 
 func (r IdentifiedResources) List(labelSelector labels.Selector, resRefs []ResourceRef, opts IdentifiedResourcesListOpts) ([]Resource, error) {
@@ -23,6 +24,11 @@ func (r IdentifiedResources) List(labelSelector labels.Selector, resRefs []Resou
 	resTypes, err := r.resourceTypes.All(opts.IgnoreCachedResTypes)
 	if err != nil {
 		return nil, err
+	}
+
+	// avoid listing labeled resources for newly created app
+	if opts.NewApp {
+		return nil, nil
 	}
 
 	// TODO non-listable types

--- a/pkg/kapp/resources/labeled_resources.go
+++ b/pkg/kapp/resources/labeled_resources.go
@@ -93,6 +93,7 @@ type AllAndMatchingOpts struct {
 	ExistingNonLabeledResourcesCheck            bool
 	ExistingNonLabeledResourcesCheckConcurrency int
 	SkipResourceOwnershipCheck                  bool
+	IsNewApp                                    bool
 
 	DisallowedResourcesByLabelKeys []string
 	LabelErrorResolutionFunc       func(string, string) string
@@ -107,15 +108,22 @@ type AllAndMatchingOpts struct {
 func (a *LabeledResources) AllAndMatching(newResources []Resource, opts AllAndMatchingOpts) ([]Resource, error) {
 	defer a.logger.DebugFunc("AllAndMatching").Finish()
 
-	resources, err := a.All(opts.IdentifiedResourcesListOpts)
-	if err != nil {
-		return nil, err
+	var (
+		resources []Resource
+		err       error
+	)
+
+	// avoid listing labeled resources for newly created app
+	if !opts.IsNewApp {
+		resources, err = a.All(opts.IdentifiedResourcesListOpts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var nonLabeledResources []Resource
 
 	if opts.ExistingNonLabeledResourcesCheck {
-		var err error
 		nonLabeledResources, err = a.findNonLabeledResources(
 			resources, newResources, opts.ExistingNonLabeledResourcesCheckConcurrency)
 		if err != nil {

--- a/test/e2e/create_update_delete_test.go
+++ b/test/e2e/create_update_delete_test.go
@@ -443,3 +443,95 @@ data:
 		cleanUp()
 	})
 }
+
+func TestAppDeploy_With_Existing_OR_New_Res(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	yaml1 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  key: value
+`
+	yaml2 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+data:
+  key: value
+`
+	yaml3 := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+data:
+  key: value2
+`
+
+	name := "test-app-deploy-with-existing-res"
+	name2 := "test-app-deploy-with-new-res"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+		kapp.Run([]string{"delete", "-a", name2})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	kubectl.RunWithOpts([]string{"apply", "-f", "-"},
+		RunOpts{StdinReader: strings.NewReader(yaml1)})
+	NewPresentClusterResource("configmap", "cm1", env.Namespace, kubectl)
+
+	logger.Section("deploy app with existing resource", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--diff-changes"},
+			RunOpts{StdinReader: strings.NewReader(yaml1)})
+
+		expectedOutput := `
+@@ update configmap/cm1 (v1) namespace: kapp-test @@
+  ...
+  4,  4   metadata:
+  5     -   annotations:
+  6     -     kubectl.kubernetes.io/last-applied-configuration: |
+  7     -       {"apiVersion":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"cm1","namespace":"kapp-test"}}
+  8,  5     creationTimestamp: "2006-01-02T15:04:05Z07:00"
+      6 +   labels:
+      7 +     kapp.k14s.io/app: "-replaced-"
+      8 +     kapp.k14s.io/association: -replaced-
+`
+		out = replaceTimestampWithDfaultValue(out)
+		out = replaceLabelValues(out)
+		require.Contains(t, out, expectedOutput, "output does not match")
+	})
+
+	logger.Section("deploy app with all new resources", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2},
+			RunOpts{StdinReader: strings.NewReader(yaml2)})
+		NewPresentClusterResource("configmap", "cm2", env.Namespace, kubectl)
+	})
+
+	logger.Section("deploy again by updating resource", func() {
+		out, _ := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name2, "--diff-changes"},
+			RunOpts{StdinReader: strings.NewReader(yaml3)})
+
+		expectedOutput := `
+@@ update configmap/cm2 (v1) namespace: kapp-test @@
+  ...
+  1,  1   data:
+  2     -   key: value
+      2 +   key: value2
+  3,  3   kind: ConfigMap
+  4,  4   metadata:
+`
+		require.Contains(t, out, expectedOutput, "output does not match")
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
When we deploy an app, we first list the labeled resources (GVs) and then try to get the non labeled resources one by one one that are not found in the first step. When an app is deployed for the first time, the first step would always return nil.

This PR has changes to avoid listing labeled resources for newly created app
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #599 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
