### PR TITLE
Update logic handling failures for kapp-controller custom resources

### DIFF
--- a/pkg/kapp/resourcesmisc/kappctrl_k14s_io_v1alpha1_app.go
+++ b/pkg/kapp/resourcesmisc/kappctrl_k14s_io_v1alpha1_app.go
@@ -51,12 +51,20 @@ func (s KappctrlK14sIoV1alpha1App) IsDoneApplying() DoneApplyState {
 			return DoneApplyState{Done: false, Message: "Reconciling"}
 
 		case cond.Type == kcv1alpha1.ReconcileFailed && cond.Status == corev1.ConditionTrue:
+			errorMsg := app.Status.UsefulErrorMessage
+			if errorMsg == "" {
+				errorMsg = cond.Message
+			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
-				"Reconcile failed: %s (message: %s)", cond.Reason, cond.Message)}
+				"Reconcile failed: %s (message: %s)", cond.Reason, errorMsg)}
 
 		case cond.Type == kcv1alpha1.DeleteFailed && cond.Status == corev1.ConditionTrue:
+			errorMsg := app.Status.UsefulErrorMessage
+			if errorMsg == "" {
+				errorMsg = cond.Message
+			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
-				"Delete failed: %s (message: %s)", cond.Reason, cond.Message)}
+				"Delete failed: %s (message: %s)", cond.Reason, errorMsg)}
 		}
 	}
 

--- a/pkg/kapp/resourcesmisc/kappctrl_k14s_io_v1alpha1_app.go
+++ b/pkg/kapp/resourcesmisc/kappctrl_k14s_io_v1alpha1_app.go
@@ -46,23 +46,19 @@ func (s KappctrlK14sIoV1alpha1App) IsDoneApplying() DoneApplyState {
 	}
 
 	for _, cond := range app.Status.Conditions {
+		errorMsg := app.Status.UsefulErrorMessage
+		if errorMsg == "" {
+			errorMsg = cond.Message
+		}
 		switch {
 		case cond.Type == kcv1alpha1.Reconciling && cond.Status == corev1.ConditionTrue:
 			return DoneApplyState{Done: false, Message: "Reconciling"}
 
 		case cond.Type == kcv1alpha1.ReconcileFailed && cond.Status == corev1.ConditionTrue:
-			errorMsg := app.Status.UsefulErrorMessage
-			if errorMsg == "" {
-				errorMsg = cond.Message
-			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Reconcile failed: %s (message: %s)", cond.Reason, errorMsg)}
 
 		case cond.Type == kcv1alpha1.DeleteFailed && cond.Status == corev1.ConditionTrue:
-			errorMsg := app.Status.UsefulErrorMessage
-			if errorMsg == "" {
-				errorMsg = cond.Message
-			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Delete failed: %s (message: %s)", cond.Reason, errorMsg)}
 		}

--- a/pkg/kapp/resourcesmisc/kappctrl_k14s_io_v1alpha1_app_test.go
+++ b/pkg/kapp/resourcesmisc/kappctrl_k14s_io_v1alpha1_app_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesmisc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctlres "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resources"
+	ctlresm "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resourcesmisc"
+)
+
+func TestKappctrlK14sIoV1alpha1AppFailure(t *testing.T) {
+	appTemplate := `
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: test-app
+  generation: 1
+status:
+  observedGeneration: 1
+  conditions:
+  - message: %s
+    status: "True"
+    type: ReconcileFailed
+  usefulErrorMessage: %s
+`
+
+	conditionMessage := "Truncated error message"
+	usefulErrorMessage := "Detailed error message"
+
+	appWithUsefulErrorMessage := fmt.Sprintf(appTemplate, conditionMessage, usefulErrorMessage)
+	state := buildKCApp(appWithUsefulErrorMessage, t).IsDoneApplying()
+	expectedState := ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: false,
+		Message:    fmt.Sprintf("Reconcile failed:  (message: %s)", usefulErrorMessage),
+	}
+	require.Equal(t, expectedState, state)
+
+	// Test that kapp falls back to message in condition if usefulErrorMessage is absent
+	appWithoutUsefulErrorMessage := fmt.Sprintf(appTemplate, conditionMessage, "")
+	state = buildKCApp(appWithoutUsefulErrorMessage, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: false,
+		Message:    fmt.Sprintf("Reconcile failed:  (message: %s)", conditionMessage),
+	}
+	require.Equal(t, state, expectedState)
+
+}
+
+func buildKCApp(resourcesBs string, t *testing.T) *ctlresm.KappctrlK14sIoV1alpha1App {
+	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
+	require.NoErrorf(t, err, "Expected resources to parse")
+
+	return ctlresm.NewKappctrlK14sIoV1alpha1App(newResources[0])
+}

--- a/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packageinstall.go
+++ b/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packageinstall.go
@@ -52,12 +52,20 @@ func (s PackagingCarvelDevV1alpha1PackageInstall) IsDoneApplying() DoneApplyStat
 			return DoneApplyState{Done: false, Message: "Reconciling"}
 
 		case cond.Type == appv1alpha1.ReconcileFailed && cond.Status == corev1.ConditionTrue:
+			errorMsg := pkgInstall.Status.UsefulErrorMessage
+			if errorMsg == "" {
+				errorMsg = cond.Message
+			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
-				"Reconcile failed: %s (message: %s)", cond.Reason, cond.Message)}
+				"Reconcile failed: %s (message: %s)", cond.Reason, errorMsg)}
 
 		case cond.Type == appv1alpha1.DeleteFailed && cond.Status == corev1.ConditionTrue:
+			errorMsg := pkgInstall.Status.UsefulErrorMessage
+			if errorMsg == "" {
+				errorMsg = cond.Message
+			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
-				"Delete failed: %s (message: %s)", cond.Reason, cond.Message)}
+				"Delete failed: %s (message: %s)", cond.Reason, errorMsg)}
 		}
 	}
 

--- a/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packageinstall.go
+++ b/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packageinstall.go
@@ -47,23 +47,19 @@ func (s PackagingCarvelDevV1alpha1PackageInstall) IsDoneApplying() DoneApplyStat
 	}
 
 	for _, cond := range pkgInstall.Status.Conditions {
+		errorMsg := pkgInstall.Status.UsefulErrorMessage
+		if errorMsg == "" {
+			errorMsg = cond.Message
+		}
 		switch {
 		case cond.Type == appv1alpha1.Reconciling && cond.Status == corev1.ConditionTrue:
 			return DoneApplyState{Done: false, Message: "Reconciling"}
 
 		case cond.Type == appv1alpha1.ReconcileFailed && cond.Status == corev1.ConditionTrue:
-			errorMsg := pkgInstall.Status.UsefulErrorMessage
-			if errorMsg == "" {
-				errorMsg = cond.Message
-			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Reconcile failed: %s (message: %s)", cond.Reason, errorMsg)}
 
 		case cond.Type == appv1alpha1.DeleteFailed && cond.Status == corev1.ConditionTrue:
-			errorMsg := pkgInstall.Status.UsefulErrorMessage
-			if errorMsg == "" {
-				errorMsg = cond.Message
-			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Delete failed: %s (message: %s)", cond.Reason, errorMsg)}
 		}

--- a/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packageinstall_test.go
+++ b/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packageinstall_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesmisc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctlres "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resources"
+	ctlresm "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resourcesmisc"
+)
+
+func TestPackagingCarvelDevV1alpha1PackageInstallFailure(t *testing.T) {
+	pkgiTemplate := `
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: test-pkgi
+  generation: 1
+status:
+  observedGeneration: 1
+  conditions:
+  - message: %s
+    status: "True"
+    type: ReconcileFailed
+  usefulErrorMessage: %s
+`
+
+	conditionMessage := "Truncated error message"
+	usefulErrorMessage := "Detailed error message"
+
+	pkgiWithUsefulErrorMessage := fmt.Sprintf(pkgiTemplate, conditionMessage, usefulErrorMessage)
+	state := buildKCPkgi(pkgiWithUsefulErrorMessage, t).IsDoneApplying()
+	expectedState := ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: false,
+		Message:    fmt.Sprintf("Reconcile failed:  (message: %s)", usefulErrorMessage),
+	}
+	require.Equal(t, expectedState, state)
+
+	// Test that kapp falls back to message in condition if usefulErrorMessage is absent
+	pkgiWithoutUsefulErrorMessage := fmt.Sprintf(pkgiTemplate, conditionMessage, "")
+	state = buildKCPkgi(pkgiWithoutUsefulErrorMessage, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: false,
+		Message:    fmt.Sprintf("Reconcile failed:  (message: %s)", conditionMessage),
+	}
+	require.Equal(t, state, expectedState)
+
+}
+
+func buildKCPkgi(resourcesBs string, t *testing.T) *ctlresm.PackagingCarvelDevV1alpha1PackageInstall {
+	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
+	require.NoErrorf(t, err, "Expected resources to parse")
+
+	return ctlresm.NewPackagingCarvelDevV1alpha1PackageInstall(newResources[0])
+}

--- a/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packagerepository.go
+++ b/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packagerepository.go
@@ -47,23 +47,19 @@ func (s PackagingCarvelDevV1alpha1PackageRepo) IsDoneApplying() DoneApplyState {
 	}
 
 	for _, cond := range pkgRepo.Status.Conditions {
+		errorMsg := pkgRepo.Status.UsefulErrorMessage
+		if errorMsg == "" {
+			errorMsg = cond.Message
+		}
 		switch {
 		case cond.Type == appv1alpha1.Reconciling && cond.Status == corev1.ConditionTrue:
 			return DoneApplyState{Done: false, Message: "Reconciling"}
 
 		case cond.Type == appv1alpha1.ReconcileFailed && cond.Status == corev1.ConditionTrue:
-			errorMsg := pkgRepo.Status.UsefulErrorMessage
-			if errorMsg == "" {
-				errorMsg = cond.Message
-			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Reconcile failed: %s (message: %s)", cond.Reason, errorMsg)}
 
 		case cond.Type == appv1alpha1.DeleteFailed && cond.Status == corev1.ConditionTrue:
-			errorMsg := pkgRepo.Status.UsefulErrorMessage
-			if errorMsg == "" {
-				errorMsg = cond.Message
-			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
 				"Delete failed: %s (message: %s)", cond.Reason, errorMsg)}
 		}

--- a/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packagerepository.go
+++ b/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packagerepository.go
@@ -52,12 +52,20 @@ func (s PackagingCarvelDevV1alpha1PackageRepo) IsDoneApplying() DoneApplyState {
 			return DoneApplyState{Done: false, Message: "Reconciling"}
 
 		case cond.Type == appv1alpha1.ReconcileFailed && cond.Status == corev1.ConditionTrue:
+			errorMsg := pkgRepo.Status.UsefulErrorMessage
+			if errorMsg == "" {
+				errorMsg = cond.Message
+			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
-				"Reconcile failed: %s (message: %s)", cond.Reason, cond.Message)}
+				"Reconcile failed: %s (message: %s)", cond.Reason, errorMsg)}
 
 		case cond.Type == appv1alpha1.DeleteFailed && cond.Status == corev1.ConditionTrue:
+			errorMsg := pkgRepo.Status.UsefulErrorMessage
+			if errorMsg == "" {
+				errorMsg = cond.Message
+			}
 			return DoneApplyState{Done: true, Successful: false, Message: fmt.Sprintf(
-				"Delete failed: %s (message: %s)", cond.Reason, cond.Message)}
+				"Delete failed: %s (message: %s)", cond.Reason, errorMsg)}
 		}
 	}
 

--- a/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packagerepository_test.go
+++ b/pkg/kapp/resourcesmisc/packaging_carvel_dev_v1alpha1_packagerepository_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesmisc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctlres "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resources"
+	ctlresm "github.com/vmware-tanzu/carvel-kapp/pkg/kapp/resourcesmisc"
+)
+
+func TestPackagingCarvelDevV1alpha1PackageRepoFailure(t *testing.T) {
+	pkgrTemplate := `
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: test-pkgr
+  generation: 1
+status:
+  observedGeneration: 1
+  conditions:
+  - message: %s
+    status: "True"
+    type: ReconcileFailed
+  usefulErrorMessage: %s
+`
+
+	conditionMessage := "Truncated error message"
+	usefulErrorMessage := "Detailed error message"
+
+	pkgrWithUsefulErrorMessage := fmt.Sprintf(pkgrTemplate, conditionMessage, usefulErrorMessage)
+	state := buildKCPkgr(pkgrWithUsefulErrorMessage, t).IsDoneApplying()
+	expectedState := ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: false,
+		Message:    fmt.Sprintf("Reconcile failed:  (message: %s)", usefulErrorMessage),
+	}
+	require.Equal(t, expectedState, state)
+
+	// Test that kapp falls back to message in condition if usefulErrorMessage is absent
+	pkgrWithoutUsefulErrorMessage := fmt.Sprintf(pkgrTemplate, conditionMessage, "")
+	state = buildKCPkgr(pkgrWithoutUsefulErrorMessage, t).IsDoneApplying()
+	expectedState = ctlresm.DoneApplyState{
+		Done:       true,
+		Successful: false,
+		Message:    fmt.Sprintf("Reconcile failed:  (message: %s)", conditionMessage),
+	}
+	require.Equal(t, state, expectedState)
+
+}
+
+func buildKCPkgr(resourcesBs string, t *testing.T) *ctlresm.PackagingCarvelDevV1alpha1PackageRepo {
+	newResources, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(resourcesBs))).Resources()
+	require.NoErrorf(t, err, "Expected resources to parse")
+
+	return ctlresm.NewPackagingCarvelDevV1alpha1PackageRepo(newResources[0])
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
It ensures that kapp shows the `usefulErrorMessage` rather than a message pointing towards it when there is a failure in a kapp-controller custom resource

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Improve failure messages for kapp-controller resources
```


##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
