### PR TITLE
Use app label as app change label for long app names

### DIFF
--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -359,7 +359,12 @@ func (a *RecordedApp) Delete() error {
 		return err
 	}
 
-	err = NewRecordedAppChanges(a.nsName, a.name, a.coreClient).DeleteAll()
+	meta, err := a.meta()
+	if err != nil {
+		return err
+	}
+
+	err = NewRecordedAppChanges(a.nsName, a.name, meta.LabelValue, a.coreClient).DeleteAll()
 	if err != nil {
 		return fmt.Errorf("Deleting app changes: %w", err)
 	}
@@ -498,7 +503,11 @@ func (a *RecordedApp) meta() (Meta, error) {
 }
 
 func (a *RecordedApp) Changes() ([]Change, error) {
-	return NewRecordedAppChanges(a.nsName, a.name, a.coreClient).List()
+	meta, err := a.meta()
+	if err != nil {
+		return nil, err
+	}
+	return NewRecordedAppChanges(a.nsName, a.name, meta.LabelValue, a.coreClient).List()
 }
 
 func (a *RecordedApp) LastChange() (Change, error) {
@@ -522,7 +531,12 @@ func (a *RecordedApp) LastChange() (Change, error) {
 }
 
 func (a *RecordedApp) BeginChange(meta ChangeMeta) (Change, error) {
-	change, err := NewRecordedAppChanges(a.nsName, a.name, a.coreClient).Begin(meta)
+	appMeta, err := a.meta()
+	if err != nil {
+		return nil, err
+	}
+
+	change, err := NewRecordedAppChanges(a.nsName, a.name, appMeta.LabelValue, a.coreClient).Begin(meta)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/app_change_test.go
+++ b/test/e2e/app_change_test.go
@@ -93,6 +93,53 @@ spec:
 	})
 }
 
+func TestAppChangeWithLongAppName(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	yaml := `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-primary
+spec:
+  ports:
+  - port: 6380
+    targetPort: 6380
+  selector:
+    app: redis
+    tier: %s
+`
+
+	name := "test-app-change-with-a-very-very-very-very-very-very-very-long-app-name"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy app", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, "backend"))})
+	})
+
+	logger.Section("deploy with changes", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, "frontend"))})
+	})
+
+	logger.Section("app change list", func() {
+		out, _ := kapp.RunWithOpts([]string{"app-change", "ls", "-a", name, "--json"}, RunOpts{})
+
+		resp := uitest.JSONUIFromBytes(t, []byte(out))
+
+		require.Equal(t, 2, len(resp.Tables[0].Rows), "Expected to have 2 app-changes")
+		require.Equal(t, "update: Op: 0 create, 0 delete, 1 update, 0 noop, 0 exists / Wait to: 1 reconcile, 0 delete, 0 noop", resp.Tables[0].Rows[0]["description"], "Expected description to match")
+		require.Equal(t, "update: Op: 1 create, 0 delete, 0 update, 0 noop, 0 exists / Wait to: 1 reconcile, 0 delete, 0 noop", resp.Tables[0].Rows[1]["description"], "Expected description to match")
+	})
+}
+
 func TestAppKindChangeWithMetadataOutput(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Use app label to as app change label for long app names
If app names have more than 63 character, use the app label as app change label instead of the app name as there is a hard limit on the number of characters that can be present in a label value

This is the first step towards fixing #646 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Use app label as app-change label if app name has more than 63 characters
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
