### PR TITLE
Revert "Use app label as app change label for long app names on 0.53.x line (#685)"

### DIFF
--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -359,12 +359,7 @@ func (a *RecordedApp) Delete() error {
 		return err
 	}
 
-	meta, err := a.meta()
-	if err != nil {
-		return err
-	}
-
-	err = NewRecordedAppChanges(a.nsName, a.name, meta.LabelValue, a.coreClient).DeleteAll()
+	err = NewRecordedAppChanges(a.nsName, a.name, a.coreClient).DeleteAll()
 	if err != nil {
 		return fmt.Errorf("Deleting app changes: %w", err)
 	}
@@ -503,11 +498,7 @@ func (a *RecordedApp) meta() (Meta, error) {
 }
 
 func (a *RecordedApp) Changes() ([]Change, error) {
-	meta, err := a.meta()
-	if err != nil {
-		return nil, err
-	}
-	return NewRecordedAppChanges(a.nsName, a.name, meta.LabelValue, a.coreClient).List()
+	return NewRecordedAppChanges(a.nsName, a.name, a.coreClient).List()
 }
 
 func (a *RecordedApp) LastChange() (Change, error) {
@@ -531,12 +522,7 @@ func (a *RecordedApp) LastChange() (Change, error) {
 }
 
 func (a *RecordedApp) BeginChange(meta ChangeMeta) (Change, error) {
-	appMeta, err := a.meta()
-	if err != nil {
-		return nil, err
-	}
-
-	change, err := NewRecordedAppChanges(a.nsName, a.name, appMeta.LabelValue, a.coreClient).Begin(meta)
+	change, err := NewRecordedAppChanges(a.nsName, a.name, a.coreClient).Begin(meta)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/app_change_test.go
+++ b/test/e2e/app_change_test.go
@@ -93,53 +93,6 @@ spec:
 	})
 }
 
-func TestAppChangeWithLongAppName(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
-
-	yaml := `
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: redis-primary
-spec:
-  ports:
-  - port: 6380
-    targetPort: 6380
-  selector:
-    app: redis
-    tier: %s
-`
-
-	name := "test-app-change-with-a-very-very-very-very-very-very-very-long-app-name"
-	cleanUp := func() {
-		kapp.Run([]string{"delete", "-a", name})
-	}
-
-	cleanUp()
-	defer cleanUp()
-
-	logger.Section("deploy app", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, "backend"))})
-	})
-
-	logger.Section("deploy with changes", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{IntoNs: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, "frontend"))})
-	})
-
-	logger.Section("app change list", func() {
-		out, _ := kapp.RunWithOpts([]string{"app-change", "ls", "-a", name, "--json"}, RunOpts{})
-
-		resp := uitest.JSONUIFromBytes(t, []byte(out))
-
-		require.Equal(t, 2, len(resp.Tables[0].Rows), "Expected to have 2 app-changes")
-		require.Equal(t, "update: Op: 0 create, 0 delete, 1 update, 0 noop, 0 exists / Wait to: 1 reconcile, 0 delete, 0 noop", resp.Tables[0].Rows[0]["description"], "Expected description to match")
-		require.Equal(t, "update: Op: 1 create, 0 delete, 0 update, 0 noop, 0 exists / Wait to: 1 reconcile, 0 delete, 0 noop", resp.Tables[0].Rows[1]["description"], "Expected description to match")
-	})
-}
-
 func TestAppKindChangeWithMetadataOutput(t *testing.T) {
 	env := BuildEnv(t)
 	logger := Logger{}


### PR DESCRIPTION
Reverts carvel-dev/kapp#691