### PR TITLE
Moving release process to goreleaser in 0.54.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   kappreleaser:
     name: kapp release
     runs-on: ubuntu-latest
+    # Set permissions of github token. See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,14 +23,15 @@ jobs:
         with:
           go-version: "1.19.5"
 
-      - name: Build kapp Script
-        run: |
-          ./hack/build-binaries.sh
-          shasum -a 256 ./kapp-* | tee checksums.txt
-          echo "# :open_file_folder: Files Checksum" | tee checksums-formatted.txt
-          echo \`\`\` | tee -a checksums-formatted.txt
-          cat checksums.txt | tee -a checksums-formatted.txt
-          echo \`\`\` | tee -a checksums-formatted.txt
+      - name: Run GoReleaser
+        # GoReleaser v2.5.0
+        uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          version: 0.184.0
+          args: release --rm-dist --debug ${{ env.SKIP_PUBLISH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Minikube
         run: |
@@ -39,31 +43,23 @@ jobs:
           # Ensure that there is no existing kapp installed
           rm -f /tmp/bin/kapp
 
-      - name: Add kapp binary to the Path
+      - name: Run Test cases
         run: |
+          # Build kapp binary
+          set -e -x
+          VERSION=`echo ${{ github.ref }}  | grep -Eo '[0-9].*'`
+          ./hack/build.sh
+
+          # Add binary to the path
           mkdir bin
           mv kapp bin
-          echo "$PWD/bin" >> $GITHUB_PATH
-          echo $GITHUB_PATH
+          PATH=$PATH:$PWD/bin
+          echo $PATH
 
-      - name: Run test cases
-        run: |
+          # Run test cases
           ./hack/test-external.sh
 
-      - name: Upload binaries and create draft Release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: ${{ github.ref_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body_path: ./checksums-formatted.txt
-          files: |
-            kapp-*
-            checksums.txt
-          draft: true
-          prerelease: true
-
-      - name: Get uploaded release YAML checksum
-        uses: actions/github-script@v4
+      - uses: actions/github-script@v4
         id: get-checksums-from-draft-release
         if: startsWith(github.ref, 'refs/tags/')
         with:
@@ -104,6 +100,7 @@ jobs:
               }
             }
             console.log(checksums)
+
             return `${checksums['kapp-darwin-amd64']}  ./kapp-darwin-amd64
             ${checksums['kapp-darwin-arm64']}  ./kapp-darwin-arm64
             ${checksums['kapp-linux-amd64']}  ./kapp-linux-amd64
@@ -116,8 +113,11 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           set -e -x
-          cat ./checksums.txt
-          diff ./checksums.txt <(cat <<EOF
+          VERSION=`echo ${{ github.ref }}  | grep -Eo '[0-9].*'`
+
+          ./hack/build-binaries.sh "$VERSION" > ./go-checksums
+          cat ./go-checksums
+          diff ./go-checksums <(cat <<EOF
           ${{steps.get-checksums-from-draft-release.outputs.result}}
           EOF
           )

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,8 @@
 # Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
+    - go fmt ./cmd/... ./pkg/... ./test/...
+    - go mod vendor
     - go mod tidy
 builds:
   - env:
@@ -13,6 +15,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     main: ./cmd/kapp
     binary: kapp-{{ .Os }}-{{ .Arch }}
 
@@ -40,8 +45,8 @@ snapshot:
 release:
   # Repo in which the release will be created.
   github:
-    owner: vmware-tanzu
-    name: carvel-kapp
+    owner: carvel-dev
+    name: kapp
 
   # If set to true, will not auto-publish the release.
   draft: true

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -2,13 +2,15 @@
 
 set -e -x -u
 
-./hack/build.sh
-
 function get_latest_git_tag {
   git describe --tags | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
 }
 
 VERSION="${1:-`get_latest_git_tag`}"
+
+go fmt ./cmd/... ./pkg/... ./test/...
+go mod vendor
+go mod tidy
 
 # makes builds reproducible
 export CGO_ENABLED=0


### PR DESCRIPTION
Moving release process to goreleaser in 0.54.x

Signed-off-by: rohitagg2020 <rohit.aggarwal2020@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
