### PR TITLE
Use app label as app-change label for new apps

### DIFF
--- a/pkg/kapp/app/recorded_app_changes.go
+++ b/pkg/kapp/app/recorded_app_changes.go
@@ -17,22 +17,24 @@ import (
 )
 
 const (
-	isChangeLabelKey   = "kapp.k14s.io/is-app-change"
-	isChangeLabelValue = ""
-	changeLabelKey     = "kapp.k14s.io/app-change-app" // holds app name or label
+	isChangeLabelKey     = "kapp.k14s.io/is-app-change"
+	isChangeLabelValue   = ""
+	legacyChangeLabelKey = "kapp.k14s.io/app-change-app"       // holds app name
+	changeLabelKey       = "kapp.k14s.io/app-change-app-label" // holds app label
 )
 
 type RecordedAppChanges struct {
-	nsName  string
-	appName string
+	nsName           string
+	appName          string
+	changeLabelValue string
 
-	appLabelValue string
+	appChangeUsesAppLabel bool
 
 	coreClient kubernetes.Interface
 }
 
-func NewRecordedAppChanges(nsName, appName, appLabelValue string, coreClient kubernetes.Interface) RecordedAppChanges {
-	return RecordedAppChanges{nsName, appName, appLabelValue, coreClient}
+func NewRecordedAppChanges(nsName, appName, changeLabelValue string, appChangeUsesAppLabel bool, coreClient kubernetes.Interface) RecordedAppChanges {
+	return RecordedAppChanges{nsName, appName, changeLabelValue, appChangeUsesAppLabel, coreClient}
 }
 
 func (a RecordedAppChanges) List() ([]Change, error) {
@@ -41,8 +43,17 @@ func (a RecordedAppChanges) List() ([]Change, error) {
 	listOpts := metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
 			isChangeLabelKey: isChangeLabelValue,
-			changeLabelKey:   a.changeLabelValue(),
+			changeLabelKey:   a.changeLabelValue,
 		}).String(),
+	}
+
+	if !a.appChangeUsesAppLabel {
+		listOpts = metav1.ListOptions{
+			LabelSelector: labels.Set(map[string]string{
+				isChangeLabelKey:     isChangeLabelValue,
+				legacyChangeLabelKey: a.appName,
+			}).String(),
+		}
 	}
 
 	changes, err := a.coreClient.CoreV1().ConfigMaps(a.nsName).List(context.TODO(), listOpts)
@@ -73,8 +84,17 @@ func (a RecordedAppChanges) DeleteAll() error {
 	listOpts := metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
 			isChangeLabelKey: isChangeLabelValue,
-			changeLabelKey:   a.changeLabelValue(),
+			changeLabelKey:   a.changeLabelValue,
 		}).String(),
+	}
+
+	if !a.appChangeUsesAppLabel {
+		listOpts = metav1.ListOptions{
+			LabelSelector: labels.Set(map[string]string{
+				isChangeLabelKey:     isChangeLabelValue,
+				legacyChangeLabelKey: a.appName,
+			}).String(),
+		}
 	}
 
 	changes, err := a.coreClient.CoreV1().ConfigMaps(a.nsName).List(context.TODO(), listOpts)
@@ -105,10 +125,16 @@ func (a RecordedAppChanges) Begin(meta ChangeMeta) (*ChangeImpl, error) {
 			Namespace:    a.nsName,
 			Labels: map[string]string{
 				isChangeLabelKey: isChangeLabelValue,
-				changeLabelKey:   a.changeLabelValue(),
+				changeLabelKey:   a.changeLabelValue,
 			},
 		},
 		Data: newMeta.AsData(),
+	}
+
+	// Keep app changes backward compatible if possible, by adding legacy
+	// change label key when app name's length is less than maximum allowed length of a label
+	if !a.appChangeUsesAppLabel || len(a.appName) <= validation.LabelValueMaxLength {
+		configMap.ObjectMeta.Labels[legacyChangeLabelKey] = a.appName
 	}
 
 	createdChange, err := a.coreClient.CoreV1().ConfigMaps(a.nsName).Create(context.TODO(), configMap, metav1.CreateOptions{})
@@ -124,11 +150,4 @@ func (a RecordedAppChanges) Begin(meta ChangeMeta) (*ChangeImpl, error) {
 	}
 
 	return change, nil
-}
-
-func (a RecordedAppChanges) changeLabelValue() string {
-	if len(a.appName) > validation.LabelValueMaxLength {
-		return a.appLabelValue
-	}
-	return a.appName
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Introduce a new label `kapp.k14s.io/app-change-app-label` for app changes which uses the app label as value
- Use the old label to list and delete app-changes created for exiting apps, but also add this new label to them.
- Use the new label to list and delete app-changes created for new apps, but add the old label if length of app name is less than the maximum allowed length of a label key to keep the app-change backward compatible

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #646 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Breaking change!!
App label generated by kapp will be used as app-change label instead of the app name for all the new apps.
- Using app name as a label value in app changes puts a limit on the number of characters a app name can have
- If an app deployed with new version of kapp (and having more than 63 characters) is used with an old version of kapp, then the old version won't be able to detect the app-changes created by the new version.
```

#### Additional Notes for your reviewer:
In future, after x number of releases, we can stop using the legacy label and start using the new label for existing apps as well. Since all the app-changes created for them would most probably have both the labels, it won't result in any loss of app-changes.

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
