### PR TITLE
Use CreateOrUpdate for --prev-app flag

### DIFF
--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -22,11 +22,10 @@ type App interface {
 	UsedGKs() (*[]schema.GroupKind, error)
 	UpdateUsedGVsAndGKs([]schema.GroupVersion, []schema.GroupKind) error
 
-	CreateOrUpdate(map[string]string, bool) (bool, error)
+	CreateOrUpdate(string, map[string]string, bool) (bool, error)
 	Exists() (bool, string, error)
 	Delete() error
 	Rename(string, string) error
-	RenamePrevApp(string, map[string]string, bool) error
 
 	// Sorted as first is oldest
 	Changes() ([]Change, error)

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -44,7 +44,7 @@ func (a *LabeledApp) UsedGVs() ([]schema.GroupVersion, error)                   
 func (a *LabeledApp) UsedGKs() (*[]schema.GroupKind, error)                               { return nil, nil }
 func (a *LabeledApp) UpdateUsedGVsAndGKs([]schema.GroupVersion, []schema.GroupKind) error { return nil }
 
-func (a *LabeledApp) CreateOrUpdate(labels map[string]string, isDiffRun bool) (bool, error) {
+func (a *LabeledApp) CreateOrUpdate(prevAppName string, labels map[string]string, isDiffRun bool) (bool, error) {
 	return false, nil
 }
 func (a *LabeledApp) Exists() (bool, string, error) { return true, "", nil }
@@ -72,9 +72,6 @@ func (a *LabeledApp) Delete() error {
 }
 
 func (a *LabeledApp) Rename(_ string, _ string) error { return fmt.Errorf("Not supported") }
-func (a *LabeledApp) RenamePrevApp(_ string, _ map[string]string, _ bool) error {
-	return fmt.Errorf("Not supported")
-}
 
 func (a *LabeledApp) Meta() (Meta, error) { return Meta{}, nil }
 

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -92,7 +92,6 @@ func NewDeployCmd(o *DeployOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 }
 
 func (o *DeployOptions) Run() error {
-	var isNewApp bool
 	failingAPIServicesPolicy := o.ResourceTypesFlags.FailingAPIServicePolicy()
 
 	app, supportObjs, err := Factory(o.depsFactory, o.AppFlags, o.ResourceTypesFlags, o.logger)
@@ -105,11 +104,7 @@ func (o *DeployOptions) Run() error {
 		return err
 	}
 
-	if o.PrevAppFlags.PrevAppName != "" {
-		err = app.RenamePrevApp(o.PrevAppFlags.PrevAppName, appLabels, o.DiffFlags.Run)
-	} else {
-		isNewApp, err = app.CreateOrUpdate(appLabels, o.DiffFlags.Run)
-	}
+	isNewApp, err := app.CreateOrUpdate(o.PrevAppFlags.PrevAppName, appLabels, o.DiffFlags.Run)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Use CreateOrUpdate for --prev-app flag
- Remove RenamePrevApp method
- Do not list labeled resources for a new app when --prev-app flag is used

#### Additional Notes for your reviewer:
RenamePrevApp has the same functionality as CreateOrUpdate + logic for prev app, and having them as separate method is leading to increase in complexity when new changes are made because of the various different code paths that we need to cover.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
