### PR TITLE
Improving performance enhancement specifically during diff stage

### DIFF
--- a/pkg/kapp/config/config.go
+++ b/pkg/kapp/config/config.go
@@ -157,11 +157,14 @@ func NewConfigFromResource(res ctlres.Resource) (Config, error) {
 		return Config{}, err
 	}
 
-	var config Config
+	return newConfigFromYAMLBytes(bs, res.Description())
+}
 
-	err = yaml.Unmarshal(bs, &config)
+func newConfigFromYAMLBytes(bs []byte, description string) (Config, error) {
+	var config Config
+	err := yaml.Unmarshal(bs, &config)
 	if err != nil {
-		return Config{}, fmt.Errorf("Unmarshaling %s: %w", res.Description(), err)
+		return Config{}, fmt.Errorf("Unmarshaling %s: %w", description, err)
 	}
 
 	err = config.Validate()

--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -700,10 +700,18 @@ changeRuleBindings:
       - hasNamespaceMatcher: {}
 `
 
-var defaultConfigRes = ctlres.MustNewResourceFromBytes([]byte(defaultConfigYAML))
-
 func NewDefaultConfigString() string { return defaultConfigYAML }
 
 func NewConfFromResourcesWithDefaults(resources []ctlres.Resource) ([]ctlres.Resource, Conf, error) {
-	return NewConfFromResources(append([]ctlres.Resource{defaultConfigRes}, resources...))
+	resources, conf, err := NewConfFromResources(resources)
+	if err != nil {
+		return nil, Conf{}, err
+	}
+
+	defaultConfig, err := newConfigFromYAMLBytes([]byte(defaultConfigYAML), "config/default (kapp.k14s.io/v1alpha1)")
+	if err != nil {
+		return nil, Conf{}, err
+	}
+
+	return resources, Conf{append([]Config{defaultConfig}, conf.configs...)}, err
 }

--- a/pkg/kapp/diff/change.go
+++ b/pkg/kapp/diff/change.go
@@ -45,6 +45,7 @@ type ChangeImpl struct {
 
 	configurableTextDiff *ConfigurableTextDiff
 	opsDiff              *OpsDiff
+	changeOpVal          ChangeOp
 }
 
 var _ Change = &ChangeImpl{}
@@ -86,6 +87,13 @@ func (d *ChangeImpl) AppliedResource() ctlres.Resource         { return d.applie
 func (d *ChangeImpl) ClusterOriginalResource() ctlres.Resource { return d.clusterOriginalRes }
 
 func (d *ChangeImpl) Op() ChangeOp {
+	if d.changeOpVal == "" {
+		d.changeOpVal = d.op()
+	}
+	return d.changeOpVal
+}
+
+func (d *ChangeImpl) op() ChangeOp {
 	if d.newRes != nil {
 		if _, hasNoopAnnotation := d.newRes.Annotations()[ctlres.NoopAnnKey]; hasNoopAnnotation {
 			return ChangeOpNoop

--- a/pkg/kapp/diff/rebased_resource.go
+++ b/pkg/kapp/diff/rebased_resource.go
@@ -42,17 +42,19 @@ func (r RebasedResource) Resource() (ctlres.Resource, error) {
 	}
 
 	for _, t := range r.mods {
-		// copy newRes and existingRes as they may be modified in place
-		resSources := map[ctlres.FieldCopyModSource]ctlres.Resource{
-			ctlres.FieldCopyModSourceNew:      r.newRes.DeepCopy(),
-			ctlres.FieldCopyModSourceExisting: r.existingRes.DeepCopy(),
-			// Might be useful for more advanced rebase rules like ytt-based
-			ctlres.FieldCopyModSource("_current"): result.DeepCopy(),
-		}
+		if t.IsResourceMatching(result) {
+			// copy newRes and existingRes as they may be modified in place
+			resSources := map[ctlres.FieldCopyModSource]ctlres.Resource{
+				ctlres.FieldCopyModSourceNew:      r.newRes.DeepCopy(),
+				ctlres.FieldCopyModSourceExisting: r.existingRes.DeepCopy(),
+				// Might be useful for more advanced rebase rules like ytt-based
+				ctlres.FieldCopyModSource("_current"): result.DeepCopy(),
+			}
 
-		err := t.ApplyFromMultiple(result, resSources)
-		if err != nil {
-			return nil, fmt.Errorf("Applying rebase rule to %s: %w", resultDesc, err)
+			err := t.ApplyFromMultiple(result, resSources)
+			if err != nil {
+				return nil, fmt.Errorf("Applying rebase rule to %s: %w", resultDesc, err)
+			}
 		}
 	}
 

--- a/pkg/kapp/diff/resource_with_history.go
+++ b/pkg/kapp/diff/resource_with_history.go
@@ -131,12 +131,6 @@ func (r ResourceWithHistory) CalculateChange(appliedRes ctlres.Resource) (Change
 	return r.newExactHistorylessChange(existingRes, appliedRes)
 }
 
-// calculateChangePrev1 is a previous version of CalculateChange
-// that we need to calculate changes in backwards compatible way.
-func (r ResourceWithHistory) calculateChangePrev1(appliedRes ctlres.Resource) (Change, error) {
-	return r.newExactHistorylessChange(r.resource, appliedRes)
-}
-
 func (r ResourceWithHistory) recalculateLastAppliedChange() ([]Change, string, string) {
 	lastAppliedResBytes := r.resource.Annotations()[appliedResAnnKey]
 	lastAppliedDiffMD5 := r.resource.Annotations()[appliedResDiffMD5AnnKey]
@@ -150,22 +144,14 @@ func (r ResourceWithHistory) recalculateLastAppliedChange() ([]Change, string, s
 		return nil, "", ""
 	}
 
-	// Continue to calculate historyless change with excluded fields
-	// (previous kapp versions did so, and we do not want to fallback
-	// to diffing against list resources).
-	recalculatedChange1, err := r.calculateChangePrev1(lastAppliedRes)
-	if err != nil {
-		return nil, "", "" // TODO deal with error?
-	}
-
-	recalculatedChange2, err := r.CalculateChange(lastAppliedRes)
+	recalculatedChange, err := r.CalculateChange(lastAppliedRes)
 	if err != nil {
 		return nil, "", "" // TODO deal with error?
 	}
 
 	lastAppliedDiff := r.resource.Annotations()[debugAppliedResDiffAnnKey]
 
-	return []Change{recalculatedChange1, recalculatedChange2}, lastAppliedDiffMD5, lastAppliedDiff
+	return []Change{recalculatedChange}, lastAppliedDiffMD5, lastAppliedDiff
 }
 
 func (r ResourceWithHistory) newExactHistorylessChange(existingRes, newRes ctlres.Resource) (Change, error) {

--- a/pkg/kapp/resources/mod_field_copy.go
+++ b/pkg/kapp/resources/mod_field_copy.go
@@ -22,11 +22,14 @@ type FieldCopyMod struct {
 
 var _ ResourceModWithMultiple = FieldCopyMod{}
 
-func (t FieldCopyMod) ApplyFromMultiple(res Resource, srcs map[FieldCopyModSource]Resource) error {
+func (t FieldCopyMod) IsResourceMatching(res Resource) bool {
 	if res == nil || !t.ResourceMatcher.Matches(res) {
-		return nil
+		return false
 	}
+	return true
+}
 
+func (t FieldCopyMod) ApplyFromMultiple(res Resource, srcs map[FieldCopyModSource]Resource) error {
 	// Make a copy of resource, to avoid modifications
 	// that may be done even in case when there is nothing to copy
 	updatedRes := res.DeepCopy()

--- a/pkg/kapp/resources/mod_field_remove.go
+++ b/pkg/kapp/resources/mod_field_remove.go
@@ -15,14 +15,18 @@ type FieldRemoveMod struct {
 var _ ResourceMod = FieldRemoveMod{}
 var _ ResourceModWithMultiple = FieldCopyMod{}
 
+func (t FieldRemoveMod) IsResourceMatching(res Resource) bool {
+	if res == nil || !t.ResourceMatcher.Matches(res) {
+		return false
+	}
+	return true
+}
+
 func (t FieldRemoveMod) ApplyFromMultiple(res Resource, _ map[FieldCopyModSource]Resource) error {
 	return t.Apply(res)
 }
 
 func (t FieldRemoveMod) Apply(res Resource) error {
-	if !t.ResourceMatcher.Matches(res) {
-		return nil
-	}
 	err := t.apply(res.unstructured().Object, t.Path)
 	if err != nil {
 		return fmt.Errorf("FieldRemoveMod for path '%s' on resource '%s': %w", t.Path.AsString(), res.Description(), err)

--- a/pkg/kapp/resources/mod_path.go
+++ b/pkg/kapp/resources/mod_path.go
@@ -15,6 +15,7 @@ type ResourceMod interface {
 
 type ResourceModWithMultiple interface {
 	ApplyFromMultiple(Resource, map[FieldCopyModSource]Resource) error
+	IsResourceMatching(resource Resource) bool
 }
 
 type Path []*PathPart

--- a/pkg/kapp/yttresmod/overlay_contract_v1_mod.go
+++ b/pkg/kapp/yttresmod/overlay_contract_v1_mod.go
@@ -23,11 +23,14 @@ type OverlayContractV1Mod struct {
 
 var _ ctlres.ResourceModWithMultiple = OverlayContractV1Mod{}
 
-func (t OverlayContractV1Mod) ApplyFromMultiple(res ctlres.Resource, srcs map[ctlres.FieldCopyModSource]ctlres.Resource) error {
-	if !t.ResourceMatcher.Matches(res) {
-		return nil
+func (t OverlayContractV1Mod) IsResourceMatching(res ctlres.Resource) bool {
+	if res == nil || !t.ResourceMatcher.Matches(res) {
+		return false
 	}
+	return true
+}
 
+func (t OverlayContractV1Mod) ApplyFromMultiple(res ctlres.Resource, srcs map[ctlres.FieldCopyModSource]ctlres.Resource) error {
 	result, err := t.evalYtt(res, srcs)
 	if err != nil {
 		return fmt.Errorf("Applying ytt (overlayContractV1): %w", err)


### PR DESCRIPTION
Improving performance enhancement specifically during diff stage.

By `go profiling`, we have noticed that there are too many calls to [deepCopy](https://github.com/carvel-dev/kapp/blob/b75689aedd76c2e022a8497473acd1e5facf2210/pkg/kapp/resources/resource.go#L236) and [AsYAMLBytes](https://github.com/carvel-dev/kapp/blob/develop/pkg/kapp/resources/resource.go#L248)

**Improvements done:**
1. While rebas'ing a resource, we wont do `Deepcopy` until the resource being rebased matches with the resource for which rebase resource is defined.
2. `default.go` which was already in yaml was unnecessary being converted to struct and then back to yaml. Removed this unnecessary conversion.
3. Reduced calls to `AsYAMLBytes`.


**Only one breaking scenario w.r.t. changes proposed:**
1. kapp deploy (config with deployment) with v0.15.0 or earlier. Most of the times, revision is not set while storing md5. But sometimes it can. Lets move forward with scenario where it can.
2. There has been no changes.
3. kapp deploy (config with deployment) with these changes. In this case, the user will see the diff’s.

The chances of this scenario are extremely low…


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
