### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/pkg/kapp/cmd/appgroup/deploy.go
+++ b/pkg/kapp/cmd/appgroup/deploy.go
@@ -5,8 +5,8 @@ package appgroup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"path/filepath"
 
 	"github.com/cppforlife/go-cli-ui/ui"
@@ -121,7 +121,7 @@ func (o *DeployOptions) appsToUpdate() (map[string]appGroupApp, error) {
 	result := map[string]appGroupApp{}
 	dir := o.DeployFlags.Directory
 
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("Reading directory '%s': %w", dir, err)
 	}

--- a/pkg/kapp/diffgraph/change_graph_cf_for_k8s_test.go
+++ b/pkg/kapp/diffgraph/change_graph_cf_for_k8s_test.go
@@ -4,7 +4,7 @@
 package diffgraph_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestChangeGraphCFForK8sUpsert(t *testing.T) {
-	configYAML, err := ioutil.ReadFile("assets/cf-for-k8s.yml")
+	configYAML, err := os.ReadFile("assets/cf-for-k8s.yml")
 	require.NoErrorf(t, err, "Reading cf-for-k8s asset")
 
 	configRs, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(configYAML))).Resources()
@@ -46,7 +46,7 @@ func TestChangeGraphCFForK8sUpsert(t *testing.T) {
 }
 
 func TestChangeGraphCFForK8sDelete(t *testing.T) {
-	configYAML, err := ioutil.ReadFile("assets/cf-for-k8s.yml")
+	configYAML, err := os.ReadFile("assets/cf-for-k8s.yml")
 	require.NoErrorf(t, err, "Reading cf-for-k8s asset")
 
 	configRs, err := ctlres.NewFileResource(ctlres.NewBytesSource([]byte(configYAML))).Resources()

--- a/pkg/kapp/resources/file_sources.go
+++ b/pkg/kapp/resources/file_sources.go
@@ -5,7 +5,7 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 )
@@ -31,7 +31,7 @@ var _ FileSource = StdinSource{}
 
 func NewStdinSource() StdinSource            { return StdinSource{} }
 func (s StdinSource) Description() string    { return "stdin" }
-func (s StdinSource) Bytes() ([]byte, error) { return ioutil.ReadAll(os.Stdin) }
+func (s StdinSource) Bytes() ([]byte, error) { return io.ReadAll(os.Stdin) }
 
 type LocalFileSource struct {
 	path string
@@ -41,7 +41,7 @@ var _ FileSource = LocalFileSource{}
 
 func NewLocalFileSource(path string) LocalFileSource { return LocalFileSource{path} }
 func (s LocalFileSource) Description() string        { return fmt.Sprintf("file '%s'", s.path) }
-func (s LocalFileSource) Bytes() ([]byte, error)     { return ioutil.ReadFile(s.path) }
+func (s LocalFileSource) Bytes() ([]byte, error)     { return os.ReadFile(s.path) }
 
 type HTTPFileSource struct {
 	url    string
@@ -68,7 +68,7 @@ func (s HTTPFileSource) Bytes() ([]byte, error) {
 		return nil, fmt.Errorf("Requesting URL '%s': %s", s.url, resp.Status)
 	}
 
-	result, err := ioutil.ReadAll(resp.Body)
+	result, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Reading URL '%s': %w", s.url, err)
 	}

--- a/pkg/kapp/resources/file_sources_test.go
+++ b/pkg/kapp/resources/file_sources_test.go
@@ -6,7 +6,7 @@ package resources_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestHTTPFileSources(t *testing.T) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Body: io.NopCloser(bytes.NewBufferString(`OK`)),
 			// Must be set to non-nil value or it panics
 			Header: make(http.Header),
 		}
@@ -41,7 +41,7 @@ func TestHTTPFileSources(t *testing.T) {
 		require.Equal(t, req.URL.String(), url)
 		return &http.Response{
 			StatusCode: http.StatusIMUsed,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`OK`)),
 			Header:     make(http.Header),
 		}
 	})

--- a/test/e2e/update_retry_on_conflict_test.go
+++ b/test/e2e/update_retry_on_conflict_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -325,7 +324,7 @@ func (p promptOutput) WaitPresented() {
 }
 
 func newTmpFile(content string, t *testing.T) *os.File {
-	file, err := ioutil.TempFile("", "kapp-test-update-retry-on-conflict")
+	file, err := os.CreateTemp("", "kapp-test-update-retry-on-conflict")
 	require.NoError(t, err)
 
 	_, err = file.Write([]byte(content))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
"io/ioutil" has been deprecated since Go 1.19
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
