### PR TITLE
Do not create change when app-changes-max-to-keep=0

### DIFF
--- a/pkg/kapp/app/change.go
+++ b/pkg/kapp/app/change.go
@@ -20,6 +20,8 @@ type ChangeImpl struct {
 	meta       ChangeMeta
 
 	createdAt time.Time
+
+	appChangesMaxToKeep int
 }
 
 var _ Change = &ChangeImpl{}
@@ -55,6 +57,11 @@ func (c *ChangeImpl) Delete() error {
 }
 
 func (c *ChangeImpl) update(doFunc func(*ChangeMeta)) error {
+	if c.appChangesMaxToKeep == 0 {
+		doFunc(&c.meta)
+		return nil
+	}
+
 	change, err := c.coreClient.CoreV1().ConfigMaps(c.nsName).Get(context.TODO(), c.name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("Getting app change: %w", err)

--- a/pkg/kapp/app/interfaces.go
+++ b/pkg/kapp/app/interfaces.go
@@ -30,7 +30,7 @@ type App interface {
 	// Sorted as first is oldest
 	Changes() ([]Change, error)
 	LastChange() (Change, error)
-	BeginChange(ChangeMeta) (Change, error)
+	BeginChange(ChangeMeta, int) (Change, error)
 	GCChanges(max int, reviewFunc func(changesToDelete []Change) error) (int, int, error)
 }
 

--- a/pkg/kapp/app/labeled_app.go
+++ b/pkg/kapp/app/labeled_app.go
@@ -75,9 +75,9 @@ func (a *LabeledApp) Rename(_ string, _ string) error { return fmt.Errorf("Not s
 
 func (a *LabeledApp) Meta() (Meta, error) { return Meta{}, nil }
 
-func (a *LabeledApp) Changes() ([]Change, error)             { return nil, nil }
-func (a *LabeledApp) LastChange() (Change, error)            { return nil, nil }
-func (a *LabeledApp) BeginChange(ChangeMeta) (Change, error) { return NoopChange{}, nil }
+func (a *LabeledApp) Changes() ([]Change, error)                  { return nil, nil }
+func (a *LabeledApp) LastChange() (Change, error)                 { return nil, nil }
+func (a *LabeledApp) BeginChange(ChangeMeta, int) (Change, error) { return NoopChange{}, nil }
 func (a *LabeledApp) GCChanges(_ int, _ func(changesToDelete []Change) error) (int, int, error) {
 	return 0, 0, nil
 }

--- a/pkg/kapp/app/recorded_app.go
+++ b/pkg/kapp/app/recorded_app.go
@@ -510,7 +510,7 @@ func (a *RecordedApp) LastChange() (Change, error) {
 		return nil, err
 	}
 
-	if len(meta.LastChangeName) == 0 {
+	if meta.LastChange.Successful == nil {
 		return nil, nil
 	}
 
@@ -524,13 +524,13 @@ func (a *RecordedApp) LastChange() (Change, error) {
 	return change, nil
 }
 
-func (a *RecordedApp) BeginChange(meta ChangeMeta) (Change, error) {
+func (a *RecordedApp) BeginChange(meta ChangeMeta, appChangesMaxToKeep int) (Change, error) {
 	appMeta, err := a.meta()
 	if err != nil {
 		return nil, err
 	}
 
-	change, err := NewRecordedAppChanges(a.nsName, a.name, appMeta.LabelValue, a.appChangesUseAppLabel, a.coreClient).Begin(meta)
+	change, err := NewRecordedAppChanges(a.nsName, a.name, appMeta.LabelValue, a.appChangesUseAppLabel, a.coreClient).Begin(meta, appChangesMaxToKeep)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kapp/app/touch.go
+++ b/pkg/kapp/app/touch.go
@@ -8,6 +8,8 @@ type Touch struct {
 	Description      string
 	Namespaces       []string
 	IgnoreSuccessErr bool
+
+	AppChangesMaxToKeep int
 }
 
 func (t Touch) Do(doFunc func() error) error {
@@ -16,7 +18,7 @@ func (t Touch) Do(doFunc func() error) error {
 		Namespaces:  t.Namespaces,
 	}
 
-	change, err := t.App.BeginChange(meta)
+	change, err := t.App.BeginChange(meta, t.AppChangesMaxToKeep)
 	if err != nil {
 		return err
 	}

--- a/pkg/kapp/cmd/app/deploy.go
+++ b/pkg/kapp/cmd/app/deploy.go
@@ -220,10 +220,11 @@ func (o *DeployOptions) Run() error {
 	}()
 
 	touch := ctlapp.Touch{
-		App:              app,
-		Description:      "update: " + changeSummary,
-		Namespaces:       nsNames,
-		IgnoreSuccessErr: true,
+		App:                 app,
+		Description:         "update: " + changeSummary,
+		Namespaces:          nsNames,
+		IgnoreSuccessErr:    true,
+		AppChangesMaxToKeep: o.DeployFlags.AppChangesMaxToKeep,
 	}
 
 	err = touch.Do(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Do not create change when app-changes-max-to-keep=0.
Existing behaviour for --app-changes-max-to-keep=0:
- Create an app change before deployment begins, and garbage collect it at the end

New behaviour: 
- Do not create an app change at all, but still keep the last change details in the meta configmap.

If app changes are already present for an app, and we set the flag value to 0, then it would still need to clean up old app changes.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #806 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
