### PR TITLE
Patch resource history annotations instead of update

### DIFF
--- a/pkg/kapp/diff/resource_with_history.go
+++ b/pkg/kapp/diff/resource_with_history.go
@@ -4,6 +4,7 @@
 package diff
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -68,13 +69,13 @@ func (r ResourceWithHistory) AllowsRecordingLastApplied() bool {
 	return !found
 }
 
-func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ctlres.Resource, bool, error) {
+func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (string, bool, error) {
 	// Use compact representation to take as little space as possible
 	// because annotation value max length is 262144 characters
 	// (https://github.com/vmware-tanzu/carvel-kapp/issues/48).
 	appliedResBytes, err := appliedChange.AppliedResource().AsCompactBytes()
 	if err != nil {
-		return nil, true, err
+		return "", true, err
 	}
 
 	diff := appliedChange.OpsDiff()
@@ -84,37 +85,30 @@ func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ct
 			r.resource.Description(), diff.MinimalMD5(), diff.MinimalString())
 	}
 
-	annsMod := ctlres.StringMapAppendMod{
-		ResourceMatcher: ctlres.AllMatcher{},
-		Path:            ctlres.NewPathFromStrings([]string{"metadata", "annotations"}),
-		KVs: map[string]string{
-			appliedResAnnKey:        string(appliedResBytes),
-			appliedResDiffMD5AnnKey: diff.MinimalMD5(),
+	annsKVS := map[string]string{
+		appliedResAnnKey:        string(appliedResBytes),
+		appliedResDiffMD5AnnKey: diff.MinimalMD5(),
 
-			// Following fields useful for debugging:
-			//   debugAppliedResDiffAnnKey:     diff.MinimalString(),
-			//   debugAppliedResDiffFullAnnKey: diff.FullString(),
-		},
+		// Following fields useful for debugging:
+		//   debugAppliedResDiffAnnKey:     diff.MinimalString(),
+		//   debugAppliedResDiffFullAnnKey: diff.FullString(),
 	}
 
 	const annValMaxLen = 262144
 
 	// kapp deploy should work without adding disable annotation when annotation value max length exceed
 	// (https://github.com/vmware-tanzu/carvel-kapp/issues/410)
-	for _, annVal := range annsMod.KVs {
+	for _, annVal := range annsKVS {
 		if len(annVal) > annValMaxLen {
-			return nil, false, nil
+			return "", false, nil
 		}
 	}
 
-	resultRes := r.resource.DeepCopy()
-
-	err = annsMod.Apply(resultRes)
+	result, err := json.Marshal(annsKVS)
 	if err != nil {
-		return nil, true, err
+		return "", false, err
 	}
-
-	return resultRes, true, nil
+	return string(result), true, nil
 }
 
 func (r ResourceWithHistory) CalculateChange(appliedRes ctlres.Resource) (Change, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Patch resource history annotations instead of update which can avoid updating the entire resource while adding the resource history annotation.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #472 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
