### PR TITLE
Updating default value for kube-api-qps and kube-api-burst for kapp

### DIFF
--- a/pkg/kapp/cmd/core/kube_api_flags.go
+++ b/pkg/kapp/cmd/core/kube_api_flags.go
@@ -14,8 +14,8 @@ type KubeAPIFlags struct {
 
 func (f *KubeAPIFlags) Set(cmd *cobra.Command, _ FlagsFactory) {
 	// Similar names are used by kubelet and other controllers
-	cmd.PersistentFlags().Float32Var(&f.QPS, "kube-api-qps", 1000, "Set Kubernetes API client QPS limit")
-	cmd.PersistentFlags().IntVar(&f.Burst, "kube-api-burst", 1000, "Set Kubernetes API client burst limit")
+	cmd.PersistentFlags().Float32Var(&f.QPS, "kube-api-qps", 50, "Set Kubernetes API client QPS limit")
+	cmd.PersistentFlags().IntVar(&f.Burst, "kube-api-burst", 100, "Set Kubernetes API client burst limit")
 }
 
 func (f *KubeAPIFlags) Configure(config ConfigFactory) {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR is changing the default values for kube-api-qps and kube-api-burst limits.
It is reducing it from 1000 (for both) to 50 for kube-api-qps and 100 for kube-api-burst.

Reasoning behind changes:
 - Kapp is used in kapp-controller for App reconciliation. kapp-controller has by default App CR concurrency of 10. so currently total api-qps = 1000*10 = 10k and burst-qps = 10k. This high qps can overload apiserver and cause slowness in cluster.
 - With lower default values of 50 for qps and 100 for burst, we limit the total api-qps to 500 and 1000 when AppCR concurrency = 10.
 - Also for any small to medium App (having less than 50 resources), the api-qps of 50 and burst of 100 are sufficient and don't cause slowness in reconcile time. 
  **TODO - add results here from excel.**
- Any large App (having more than 50 resources), the default values can be changed using the command line options.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
None
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
