### PR TITLE
Update some images in examples

### DIFF
--- a/.github/workflows/test-gh-k8s-1.16.yml
+++ b/.github/workflows/test-gh-k8s-1.16.yml
@@ -1,4 +1,4 @@
-name: test-gh-k8s-1.16
+name: test-gh-k8s-1.21
 on:
   push:
     branches:
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, synchronize]
 jobs:
   test-all:
-    name: Test GH
+    name: Test GH 1.21
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Go
@@ -34,9 +34,9 @@ jobs:
 
           wget -O- https://carvel.dev/install.sh | K14SIO_INSTALL_BIN_DIR=/tmp/bin bash
 
-          wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-linux-amd64 > /tmp/bin/minikube
-          chmod +x /tmp/bin/minikube
-          minikube start --driver=docker --kubernetes-version 1.16.0
+          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          install minikube-linux-amd64 /usr/local/bin/minikube
+          minikube start --driver=docker --kubernetes-version 1.21.0
           eval $(minikube docker-env --shell=bash)
 
           # Ensure that there is no existing kapp installed

--- a/examples/gitops/guestbook/all-in-one.yml
+++ b/examples/gitops/guestbook/all-in-one.yml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: primary
-        image: k8s.gcr.io/redis:e2e  #! or just image: redis
+        image: registry.k8s.io/redis:e2e  #! or just image: redis
         resources:
           requests:
             cpu: 120m
@@ -140,7 +140,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/examples/gitops/redis-with-configmap/redis.yml
+++ b/examples/gitops/redis-with-configmap/redis.yml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: redis
-    image: k8s.gcr.io/redis:e2e
+    image: registry.k8s.io/redis:e2e
     ports:
     - containerPort: 6379
     resources:

--- a/examples/sts-alternative/config.yml
+++ b/examples/sts-alternative/config.yml
@@ -45,7 +45,7 @@ metadata:
 spec:
   containers:
   - name: redis
-    image: k8s.gcr.io/redis:e2e
+    image: registry.k8s.io/redis:e2e
     ports:
     - containerPort: 6379
     resources:

--- a/test/e2e/wait_timeout_test.go
+++ b/test/e2e/wait_timeout_test.go
@@ -27,7 +27,7 @@ func TestWaitTimeout(t *testing.T) {
      spec: 
        containers: 
        - name: successful-job 
-         image: busybox 
+         image: busybox
          command: ["/bin/sh", "-c", "sleep 10"] 
        restartPolicy: Never
 `


### PR DESCRIPTION
Use artifact registry url instead gcr as images in gcr are not tagged anymore

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Use artefact registry url for frontend-gb instead of gcr
- Use `registry.k8s.io` instead of `k8s.gcr.io`


#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
