### PR TITLE
Update --preflight command line option

### DIFF
--- a/pkg/kapp/preflight/registry_test.go
+++ b/pkg/kapp/preflight/registry_test.go
@@ -20,42 +20,32 @@ func TestRegistrySet(t *testing.T) {
 	}{
 		{
 			name:       "no preflight checks registered, parsing skipped, any value can be provided",
-			preflights: "someCheck=true",
+			preflights: "someCheck",
 			registry:   &Registry{},
 		},
 		{
 			name:       "preflight checks registered, invalid check format in flag, error returned",
-			preflights: "some=check=something=true",
+			preflights: ",",
 			registry: &Registry{
 				known: map[string]Check{
-					"some": nil,
+					"some": NewCheck(func(_ context.Context, _ *diffgraph.ChangeGraph) error { return nil }, true),
 				},
 			},
 			shouldErr: true,
 		},
 		{
 			name:       "preflight checks registered, unknown preflight check specified, error returned",
-			preflights: "nonexistent=true",
+			preflights: "nonexistent",
 			registry: &Registry{
 				known: map[string]Check{
-					"exists": nil,
-				},
-			},
-			shouldErr: true,
-		},
-		{
-			name:       "preflight checks registered, known check specified, non-boolean value provided, error returned",
-			preflights: "someCheck=enabled",
-			registry: &Registry{
-				known: map[string]Check{
-					"someCheck": nil,
+					"exists": NewCheck(func(_ context.Context, _ *diffgraph.ChangeGraph) error { return nil }, true),
 				},
 			},
 			shouldErr: true,
 		},
 		{
 			name:       "preflight checks registered, valid input, no error returned",
-			preflights: "someCheck=true",
+			preflights: "someCheck",
 			registry: &Registry{
 				known: map[string]Check{
 					"someCheck": NewCheck(func(_ context.Context, _ *diffgraph.ChangeGraph) error { return nil }, true),

--- a/test/e2e/preflight_permission_validation_escalation_test.go
+++ b/test/e2e/preflight_permission_validation_escalation_test.go
@@ -105,7 +105,7 @@ rules:
 
 	roleResource = strings.ReplaceAll(roleResource, "__test-name__", testName)
 	logger.Section("deploy app with privilege escalation Role", func() {
-		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(roleResource)})
 
 		NewPresentClusterResource("role", testName, testName, kubectl)
@@ -129,7 +129,7 @@ roleRef:
 `
 	bindingResource = strings.ReplaceAll(bindingResource, "__test-name__", testName)
 	logger.Section("deploy app with privilege escalation RoleBinding", func() {
-		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(bindingResource)})
 
 		NewPresentClusterResource("rolebinding", testName, testName, kubectl)

--- a/test/e2e/preflight_permission_validation_failed_escalation_test.go
+++ b/test/e2e/preflight_permission_validation_failed_escalation_test.go
@@ -107,7 +107,7 @@ rules:
 
 	roleResource = strings.ReplaceAll(roleResource, "__test-name__", testName)
 	logger.Section("attempt to deploy app with privilege escalation Role without privilege escalation permissions", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(roleResource), AllowError: true})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "running preflight check \"PermissionValidation\": potential privilege escalation, not permitted to \"create\" rbac.authorization.k8s.io/v1, Kind=Role")
@@ -132,7 +132,7 @@ roleRef:
 `
 	bindingResource = strings.ReplaceAll(bindingResource, "__test-name__", testName)
 	logger.Section("attempt deploy app with privilege escalation RoleBinding without privilege escalation permissions", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(bindingResource), AllowError: true})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "running preflight check \"PermissionValidation\": potential privilege escalation, not permitted to \"create\" rbac.authorization.k8s.io/v1, Kind=RoleBinding")

--- a/test/e2e/preflight_permission_validation_missing_test.go
+++ b/test/e2e/preflight_permission_validation_missing_test.go
@@ -109,7 +109,7 @@ spec:
 `
 	basicResource = strings.ReplaceAll(basicResource, "__test-name__", testName)
 	logger.Section("attempt to deploy app with a Pod and missing permissions to create Pods", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(basicResource), AllowError: true})
 
 		require.Error(t, err)
@@ -132,7 +132,7 @@ rules:
 
 	roleResource = strings.ReplaceAll(roleResource, "__test-name__", testName)
 	logger.Section("attempt to deploy app with a Role and missing permissions to create Roles", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(roleResource), AllowError: true})
 
 		require.Error(t, err)
@@ -158,7 +158,7 @@ roleRef:
 `
 	bindingResource = strings.ReplaceAll(bindingResource, "__test-name__", testName)
 	logger.Section("attempt to deploy app with a RoleBinding and missing permissions to create RoleBindings", func() {
-		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		_, err := kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(bindingResource), AllowError: true})
 
 		require.Error(t, err)

--- a/test/e2e/preflight_permission_validation_test.go
+++ b/test/e2e/preflight_permission_validation_test.go
@@ -107,7 +107,7 @@ spec:
 `
 	basicResource = strings.ReplaceAll(basicResource, "__test-name__", testName)
 	logger.Section("deploy app with Pod with permissions to create Pods", func() {
-		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(basicResource)})
 
 		NewPresentClusterResource("pod", testName, testName, kubectl)
@@ -128,7 +128,7 @@ rules:
 
 	roleResource = strings.ReplaceAll(roleResource, "__test-name__", testName)
 	logger.Section("deploy app with Role with permissions to create Roles", func() {
-		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(roleResource)})
 
 		NewPresentClusterResource("role", testName, testName, kubectl)
@@ -152,7 +152,7 @@ roleRef:
 `
 	bindingResource = strings.ReplaceAll(bindingResource, "__test-name__", testName)
 	logger.Section("deploy app with Pod with permissions to create RoleBindings", func() {
-		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation=true", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
+		kapp.RunWithOpts([]string{"deploy", "--preflight=PermissionValidation", "-a", appName, "-f", "-", fmt.Sprintf("--kubeconfig-context=%s", scopedContext)},
 			RunOpts{StdinReader: strings.NewReader(roleResource + bindingResource)})
 
 		NewPresentClusterResource("rolebinding", testName, testName, kubectl)


### PR DESCRIPTION
Fix #893

The `--preflight` command line options now only specifies those preflight checks that are to be enables.

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This simplifies the command line `--preflight` option; we're looking to have additional configuration located in a configuration file, rather than on the command line.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #893 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Update --preflight flag to be a simple list of preflight validators to enable.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
