### PR TITLE
Default rule to make sure service-account is created before secret associated with that service-account

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -569,6 +569,14 @@ changeGroupBindings:
   resourceMatchers: &serviceAccountMatchers
   - apiVersionKindMatcher: {kind: ServiceAccount, apiVersion: v1}
 
+- name: change-groups.kapp.k14s.io/secret-associated-with-sa
+  resourceMatchers:
+  - andMatcher: 
+      matchers: 
+      - apiVersionKindMatcher: {kind: Secret, apiVersion: v1}
+      - hasAnnotationMatcher:
+              keys: [kubernetes.io/service-account.name]
+
 - name: change-groups.kapp.k14s.io/kapp-controller-app
   resourceMatchers: *appMatchers
 
@@ -587,6 +595,12 @@ changeRuleBindings:
           matcher: &disableDefaultChangeGroupAnnMatcher
             hasAnnotationMatcher:
               keys: [kapp.k14s.io/disable-default-change-group-and-rules]
+
+# Create SA before creating secret associated with SA
+- rules:
+  - "upsert before upserting change-groups.kapp.k14s.io/secret-associated-with-sa"
+  resourceMatchers:
+  - apiVersionKindMatcher: {kind: ServiceAccount, apiVersion: v1}
 
 # Delete CRs before CRDs to retain detailed observability
 # instead of having CRD deletion trigger all CR deletion

--- a/pkg/kapp/diffgraph/change_graph_test.go
+++ b/pkg/kapp/diffgraph/change_graph_test.go
@@ -809,6 +809,33 @@ metadata:
 	require.Equal(t, expectedOutput, output)
 }
 
+func TestChangeGraphWithSecretAndSA(t *testing.T) {
+	yaml := `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-0
+  annotations:
+    kubernetes.io/service-account.name: sa-0
+type: kubernetes.io/service-account-token
+`
+
+	graph, err := buildChangeGraph(yaml, ctldgraph.ActualChangeOpUpsert, t)
+	require.NoErrorf(t, err, "Expected graph to build")
+
+	output := strings.TrimSpace(graph.PrintStr())
+	expectedOutput := strings.TrimSpace(`
+(upsert) serviceaccount/sa-0 (v1) cluster
+(upsert) secret/secret-0 (v1) cluster
+`)
+	require.Equal(t, expectedOutput, output)
+}
+
 func buildChangeGraph(resourcesBs string, op ctldgraph.ActualChangeOp, t *testing.T) (*ctldgraph.ChangeGraph, error) {
 	return buildChangeGraphWithOpts(buildGraphOpts{resourcesBs: resourcesBs, op: op}, t)
 }

--- a/test/e2e/change_rule_test.go
+++ b/test/e2e/change_rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/test/e2e/change_rule_test.go
+++ b/test/e2e/change_rule_test.go
@@ -1,0 +1,119 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceAccountAssociatedSecretDefaultChangeRule(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	config := `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kapp-token-test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-0
+  namespace: kapp-token-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-0
+  namespace: kapp-token-test
+  annotations:
+    kubernetes.io/service-account.name: sa-0
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-1
+  namespace: kapp-token-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-1
+  namespace: kapp-token-test
+  annotations:
+    kubernetes.io/service-account.name: sa-1
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-2
+  namespace: kapp-token-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-2
+  namespace: kapp-token-test
+  annotations:
+    kubernetes.io/service-account.name: sa-2
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-3
+  namespace: kapp-token-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-3
+  namespace: kapp-token-test
+  annotations:
+    kubernetes.io/service-account.name: sa-3
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-4
+  namespace: kapp-token-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-4
+  namespace: kapp-token-test
+  annotations:
+    kubernetes.io/service-account.name: sa-4
+type: kubernetes.io/service-account-token
+`
+
+	name := "test-sa-created-before-secret-associated-with-sa"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+
+	logger.Section("deploy resource with secret associated with service account", func() {
+		// deploying it multiple times to make sure it's able to find secret everytime
+		for i := 0; i < 5; i++ {
+			_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{
+				StdinReader: strings.NewReader(config),
+			})
+			if err != nil {
+				require.Errorf(t, err, "Expected resources to be created")
+			}
+			cleanUp()
+		}
+	})
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Default rule to make sure secret associated with service-account created after service-account is created

#### Which issue(s) this PR fixes:
#514 
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
