### PR TITLE
Add handling of updates to required fields to the CRD Upgrade Safety preflight check

### DIFF
--- a/pkg/kapp/crdupgradesafety/preflight.go
+++ b/pkg/kapp/crdupgradesafety/preflight.go
@@ -40,6 +40,7 @@ func NewPreflight(df cmdcore.DepsFactory, enabled bool) *Preflight {
 				&ChangeValidator{
 					Validations: []ChangeValidation{
 						EnumChangeValidation,
+						RequiredFieldChangeValidation,
 					},
 				},
 			},

--- a/test/e2e/preflight_crdupgradesafety_invalid_field_change_requiredfield_added_test.go
+++ b/test/e2e/preflight_crdupgradesafety_invalid_field_change_requiredfield_added_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreflightCRDUpgradeSafetyInvalidFieldChangeRequiredFieldAdded(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	testName := "preflightcrdupgradesafetyinvalidfieldchangerequiredfieldadded"
+
+	base := `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: memcacheds.__test-name__.example.com
+spec:
+  group: __test-name__.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: string
+            properties:
+              image:
+                type: string
+              pollInterval:
+                type: string
+            required:
+              - image
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+`
+
+	base = strings.ReplaceAll(base, "__test-name__", testName)
+	appName := "preflight-crdupgradesafety-app"
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", appName})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	update := `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: memcacheds.__test-name__.example.com
+spec:
+  group: __test-name__.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: string
+            properties:
+              image:
+                type: string
+              pollInterval:
+                type: string
+            required:
+              - image
+              - pollInterval
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+`
+
+	update = strings.ReplaceAll(update, "__test-name__", testName)
+	logger.Section("deploy app with CRD update that adds a required field value, preflight check enabled, should error", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-a", appName, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(base)})
+		require.NoError(t, err)
+		_, err = kapp.RunWithOpts([]string{"deploy", "--preflight=CRDUpgradeSafety", "-a", appName, "-f", "-"},
+			RunOpts{StdinReader: strings.NewReader(update), AllowError: true})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new required fields added")
+	})
+}

--- a/test/e2e/preflight_crdupgradesafety_invalid_field_change_requiredfield_added_when_none_existed_test.go
+++ b/test/e2e/preflight_crdupgradesafety_invalid_field_change_requiredfield_added_when_none_existed_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreflightCRDUpgradeSafetyInvalidFieldChangeRequiredFieldAddedWhenNoneExisted(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	testName := "preflightcrdupgradesafetyinvalidfieldchangerequiredfieldaddedwhennonexisted"
+
+	base := `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: memcacheds.__test-name__.example.com
+spec:
+  group: __test-name__.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: string
+            properties:
+              image:
+                type: string
+              pollInterval:
+                type: string
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+`
+
+	base = strings.ReplaceAll(base, "__test-name__", testName)
+	appName := "preflight-crdupgradesafety-app"
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", appName})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	update := `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: memcacheds.__test-name__.example.com
+spec:
+  group: __test-name__.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: string
+            properties:
+              image:
+                type: string
+              pollInterval:
+                type: string
+            required:
+              - image
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+`
+
+	update = strings.ReplaceAll(update, "__test-name__", testName)
+	logger.Section("deploy app with CRD update that adds a new required field value when none existed prior to this, preflight check enabled, should error", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-a", appName, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(base)})
+		require.NoError(t, err)
+		_, err = kapp.RunWithOpts([]string{"deploy", "--preflight=CRDUpgradeSafety", "-a", appName, "-f", "-"},
+			RunOpts{StdinReader: strings.NewReader(update), AllowError: true})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new values added as required when previously no required fields existed")
+	})
+}

--- a/test/e2e/preflight_crdupgradesafety_valid_field_change_requiredfield_removed_test.go
+++ b/test/e2e/preflight_crdupgradesafety_valid_field_change_requiredfield_removed_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreflightCRDUpgradeSafetyInvalidFieldChangeRequiredFieldRemoved(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	testName := "preflightcrdupgradesafetyinvalidfieldchangerequiredfieldremoved"
+
+	base := `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: memcacheds.__test-name__.example.com
+spec:
+  group: __test-name__.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: string
+            properties:
+              image:
+                type: string
+              pollInterval:
+                type: string
+            required:
+              - image
+              - pollInterval
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+`
+
+	base = strings.ReplaceAll(base, "__test-name__", testName)
+	appName := "preflight-crdupgradesafety-app"
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", appName})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	update := `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: memcacheds.__test-name__.example.com
+spec:
+  group: __test-name__.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: string
+            properties:
+              image:
+                type: string
+              pollInterval:
+                type: string
+            required:
+              - image
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+`
+
+	update = strings.ReplaceAll(update, "__test-name__", testName)
+	logger.Section("deploy app with CRD update that removes a required field value, preflight check enabled, should not error", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-a", appName, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(base)})
+		require.NoError(t, err)
+		_, err = kapp.RunWithOpts([]string{"deploy", "--preflight=CRDUpgradeSafety", "-a", appName, "-f", "-"},
+			RunOpts{StdinReader: strings.NewReader(update), AllowError: true})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a validation check to ensure that existing required fields can be marked as optional in a CRD schema:

- Ensures that no new values are added as required that did not previously have any required fields present
- Approves when existing values are removed from the required field
- Adds unit and e2e tests

#### Which issue(s) this PR fixes:
Fixes https://github.com/carvel-dev/kapp/issues/915

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Add logic to the CRD Upgrade Safety pre-flight check to ensure that removals to the required field values of a CRD schema are allowed and that no new required fields can be added
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
