### PR TITLE
Update cron-job.yml

### DIFF
--- a/examples/jobs/cron-job.yml
+++ b/examples/jobs/cron-job.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cron-job


### PR DESCRIPTION
This change fixes this issue:

```
kapp: Error: Expected to find kind 'batch/v1beta1/CronJob', but did not:
- Kubernetes API server did not have matching apiVersion + kind
- No matching CRD was found in given configuration
```

This example is used in the docs here. https://carvel.dev/kapp-controller/docs/v0.50.x/packaging-tutorial/#optional-explore-kapp