### PR TITLE
KAPP-1000: Apply noop changes after everything else

### DIFF
--- a/pkg/kapp/clusterapply/applying_changes.go
+++ b/pkg/kapp/clusterapply/applying_changes.go
@@ -60,6 +60,8 @@ func (c *ApplyingChanges) Apply(allChanges []*ctldgraph.Change) ([]WaitingChange
 		// - "...: context canceled (reason: )"
 		applyThrottle := util.NewThrottle(c.opts.Concurrency)
 		applyCh := make(chan applyResult, len(nonAppliedChanges))
+
+		// Perform noop changes after all other changes are applied
 		allChangesAreNoop := c.allChangesAreNoop(nonAppliedChanges)
 
 		for _, change := range nonAppliedChanges {

--- a/pkg/kapp/diffgraph/change.go
+++ b/pkg/kapp/diffgraph/change.go
@@ -231,6 +231,8 @@ func (cs Changes) MatchesRule(rule ChangeRule, _ *Change) ([]*Change, error) {
 			op := change.Change.Op()
 
 			switch op {
+			case ActualChangeOpNoop:
+				// Fall through since we want noop to be treated as upsert
 			case ActualChangeOpUpsert:
 				if rule.TargetAction == ChangeRuleTargetActionUpserting {
 					result = append(result, change)
@@ -239,7 +241,6 @@ func (cs Changes) MatchesRule(rule ChangeRule, _ *Change) ([]*Change, error) {
 				if rule.TargetAction == ChangeRuleTargetActionDeleting {
 					result = append(result, change)
 				}
-			case ActualChangeOpNoop:
 			default:
 				panic(fmt.Sprintf("Unknown change operation: %s", op))
 			}

--- a/pkg/kapp/diffgraph/change.go
+++ b/pkg/kapp/diffgraph/change.go
@@ -231,8 +231,6 @@ func (cs Changes) MatchesRule(rule ChangeRule, _ *Change) ([]*Change, error) {
 			op := change.Change.Op()
 
 			switch op {
-			case ActualChangeOpNoop:
-				// Fall through since we want noop to be treated as upsert
 			case ActualChangeOpUpsert:
 				if rule.TargetAction == ChangeRuleTargetActionUpserting {
 					result = append(result, change)
@@ -241,6 +239,7 @@ func (cs Changes) MatchesRule(rule ChangeRule, _ *Change) ([]*Change, error) {
 				if rule.TargetAction == ChangeRuleTargetActionDeleting {
 					result = append(result, change)
 				}
+			case ActualChangeOpNoop:
 			default:
 				panic(fmt.Sprintf("Unknown change operation: %s", op))
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This is a workaround for the problem when a noop apply fails due to dependencies that is later in the dependency stage (even though the noop is declared to be dependent on them)

#### Which issue(s) this PR fixes:
Fixes #1000 

#### Does this PR introduce a user-facing change?
```release-note
I'm not sure of the implications of this,
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
