### PR TITLE
Providing startTime and currentTime to facilitate timeout in case of ytt wait rules

### DIFF
--- a/pkg/kapp/resourcesmisc/wait_rule_contract_v1.go
+++ b/pkg/kapp/resourcesmisc/wait_rule_contract_v1.go
@@ -16,6 +16,8 @@ import (
 type WaitRuleContractV1 struct {
 	ResourceMatcher ctlres.ResourceMatcher
 	Starlark        string
+	CurrentTime     int64
+	StartTime       int64
 }
 
 type waitRuleContractV1Result struct {
@@ -48,6 +50,7 @@ func (t WaitRuleContractV1) evalYtt(res ctlres.Resource) (*WaitRuleContractV1Res
 		}
 		return yaml.Marshal(res.DeepCopyRaw())
 	}
+	opts.DataValuesFlags.KVsFromStrings = []string{fmt.Sprintf("startTime=%d", t.StartTime), fmt.Sprintf("currentTime=%d", t.CurrentTime)}
 
 	filesToProcess := []*files.File{
 		files.MustNewFileFromSource(files.NewBytesSource("resource.star", []byte(t.Starlark))),

--- a/test/e2e/custom_wait_rules_test.go
+++ b/test/e2e/custom_wait_rules_test.go
@@ -260,3 +260,65 @@ Succeeded`))
 		require.Equal(t, expectedOutput, out)
 	})
 }
+
+func TestYTTWaitRuleWithTimeout(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	name := "test-custom-wait-rule-timeout-contract-v1"
+
+	yaml := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: %s
+    ports:
+    - containerPort: 80
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+waitRules:
+- ytt:
+    funcContractV1:
+      resource.star: |
+        def is_done(resource):
+          for condition in resource.status.conditions:
+            if condition.type == "ContainersReady" and condition.status == "False":
+              expiryTime = getExpiryTime(resource.startTime)
+              if int(resource.currentTime) - expiryTime > 0:
+                  return {"done": True, "successful": False, "message": "Continuously failed for 50s with " + condition.message}
+              else:
+                  return {"done": False, "successful": False, "message": condition.message}
+              end
+            elif condition.type == "Ready" and condition.status == "True":
+              return {"done": True, "successful": True, "message": condition.message}
+            end
+          end
+          return {"done": False, "successful": False, "message": "Not in Failed or Running state"}
+        end
+    
+        def getExpiryTime(startTime):
+        return int(startTime)+50 
+        end
+  resourceMatchers:
+  - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}
+`
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("Deploy timeout after staying in a condition for certain time with ytt wait rules", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--json"},
+			RunOpts{IntoNs: true, AllowError: true, StdinReader: strings.NewReader(fmt.Sprintf(yaml, "nginx:200"))})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Continuously failed for 50s with")
+	})
+}

--- a/test/e2e/custom_wait_rules_test.go
+++ b/test/e2e/custom_wait_rules_test.go
@@ -302,7 +302,7 @@ waitRules:
         end
     
         def getExpiryTime(startTime):
-        return int(startTime)+50 
+          return int(startTime)+50 
         end
   resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: v1, kind: Pod}


### PR DESCRIPTION
Providing startTime and currentTime to facilitate timeout in case of ytt wait rules

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
