### PR TITLE
Ensure fixed order in multi-line error returned by change validator

### DIFF
--- a/pkg/kapp/crdupgradesafety/change_validator.go
+++ b/pkg/kapp/crdupgradesafety/change_validator.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 
 	"github.com/openshift/crd-schema-checker/pkg/manifestcomparators"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -449,7 +451,10 @@ func (cv *ChangeValidator) Validate(old, new v1.CustomResourceDefinition) error 
 			continue
 		}
 
-		for field, diff := range diffs {
+		// ensure order of the potentially multi-line final error
+		for _, field := range slices.Sorted(maps.Keys(diffs)) {
+			diff := diffs[field]
+
 			handled := false
 			for _, validation := range cv.Validations {
 				ok, err := validation(diff)

--- a/pkg/kapp/crdupgradesafety/change_validator_test.go
+++ b/pkg/kapp/crdupgradesafety/change_validator_test.go
@@ -5,6 +5,7 @@ package crdupgradesafety_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"carvel.dev/kapp/pkg/kapp/crdupgradesafety"
@@ -235,12 +236,15 @@ func TestFlattenSchema(t *testing.T) {
 }
 
 func TestChangeValidator(t *testing.T) {
+	validationErr1 := errors.New(`version "v1alpha1", field "^" has unknown change, refusing to determine that change is safe`)
+	validationErr2 := errors.New(`version "v1alpha1", field "^": fail`)
+
 	for _, tc := range []struct {
 		name            string
 		changeValidator *crdupgradesafety.ChangeValidator
 		old             v1.CustomResourceDefinition
 		new             v1.CustomResourceDefinition
-		shouldError     bool
+		expectedError   error
 	}{
 		{
 			name: "no changes, no error",
@@ -347,7 +351,7 @@ func TestChangeValidator(t *testing.T) {
 					},
 				},
 			},
-			shouldError: true,
+			expectedError: validationErr1,
 		},
 		{
 			name: "changes, validation failed, change fully handled, error",
@@ -384,14 +388,17 @@ func TestChangeValidator(t *testing.T) {
 					},
 				},
 			},
-			shouldError: true,
+			expectedError: validationErr2,
 		},
 		{
-			name: "changes, validation failed, change not fully handled, error",
+			name: "changes, validation failed, change not fully handled, ordered error",
 			changeValidator: &crdupgradesafety.ChangeValidator{
 				Validations: []crdupgradesafety.ChangeValidation{
 					func(_ crdupgradesafety.FieldDiff) (bool, error) {
 						return false, errors.New("fail")
+					},
+					func(_ crdupgradesafety.FieldDiff) (bool, error) {
+						return false, errors.New("error")
 					},
 				},
 			},
@@ -421,12 +428,16 @@ func TestChangeValidator(t *testing.T) {
 					},
 				},
 			},
-			shouldError: true,
+			expectedError: fmt.Errorf("%w\n%s\n%w", validationErr2, `version "v1alpha1", field "^": error`, validationErr1),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.changeValidator.Validate(tc.old, tc.new)
-			assert.Equal(t, tc.shouldError, err != nil, "should error? - %v", tc.shouldError)
+			if tc.expectedError != nil {
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This PR introduces order to potentially multi-line error returned by ChangeValidator Validate(). Currently field validations within Validate() happen based on order returned by a map, which is not fixed/deterministic and means that the same set of internal errors can produce a different "unique" error each time, because Validate() combines all errors into a single one before it returns.

This can cause issues on the users side - eg. with errors returned by Validate ending up in objects .Status.Conditions which in turn could mean that a controller could be forced to try and reconcile status/object based on the same (yet different) error message. Please see a real-life example here: https://github.com/operator-framework/operator-controller/issues/1456 

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
