### PR TITLE
crdupgradesafety: CalculateFlatSchemaDiff should ignore child items

### DIFF
--- a/pkg/kapp/crdupgradesafety/change_validator.go
+++ b/pkg/kapp/crdupgradesafety/change_validator.go
@@ -540,8 +540,8 @@ func CalculateFlatSchemaDiff(o, n FlatSchema) (map[string]FieldDiff, error) {
 		// we should still detect changes in the children fields.
 		oldCopy := schema.DeepCopy()
 		newCopy := newSchema.DeepCopy()
-		oldCopy.Properties = nil
-		newCopy.Properties = nil
+		oldCopy.Properties, oldCopy.Items = nil, nil
+		newCopy.Properties, newCopy.Items = nil, nil
 		if !reflect.DeepEqual(oldCopy, newCopy) {
 			diffMap[field] = FieldDiff{
 				Old: oldCopy,

--- a/pkg/kapp/crdupgradesafety/change_validator_test.go
+++ b/pkg/kapp/crdupgradesafety/change_validator_test.go
@@ -188,6 +188,24 @@ func TestCalculateFlatSchemaDiff(t *testing.T) {
 			expectedDiff: map[string]crdupgradesafety.FieldDiff{},
 		},
 		{
+			name: "diff in child items only, no diff returned, no error",
+			old: crdupgradesafety.FlatSchema{
+				"foo": &v1.JSONSchemaProps{
+					Items: &v1.JSONSchemaPropsOrArray{Schema: &v1.JSONSchemaProps{
+						ID: "bar",
+					}},
+				},
+			},
+			new: crdupgradesafety.FlatSchema{
+				"foo": &v1.JSONSchemaProps{
+					Items: &v1.JSONSchemaPropsOrArray{Schema: &v1.JSONSchemaProps{
+						ID: "baz",
+					}},
+				},
+			},
+			expectedDiff: map[string]crdupgradesafety.FieldDiff{},
+		},
+		{
 			name: "field exists in old but not new, no diff returned, error",
 			old: crdupgradesafety.FlatSchema{
 				"foo": &v1.JSONSchemaProps{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

See https://github.com/operator-framework/operator-controller/issues/1860

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

The `FlatSchema` struct contains a mapping of every field at all levels of the type hierarchy containing the schema of that field. In the case of fields that are structs, the `CalculateFlatSchemaDiff` function ignores the child properties because the child properties have their own schemas defined elsewhere in the map. For this same reason, `CalculateFlatSchemaDiff` should _also_ ignore child `Items`.

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
