### PR TITLE
add `volume.kubernetes.io/storage-provisioner` annotation for default pvc rebaseRules

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -73,6 +73,7 @@ rebaseRules:
   - [metadata, annotations, pv.kubernetes.io/bound-by-controller]
   - [metadata, annotations, pv.kubernetes.io/migrated-to]
   - [metadata, annotations, volume.beta.kubernetes.io/storage-provisioner]
+  - [metadata, annotations, volume.kubernetes.io/storage-provisioner]
   - [spec, storageClassName]
   - [spec, volumeMode]
   - [spec, volumeName]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

[`volume.kubernetes.io/storage-provisioner`](https://kubernetes.io/docs/reference/labels-annotations-taints/#volume-kubernetes-io-storage-provisioner) annotation is not a part of default rebase rules for pvc, added it in this pr.


#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
