### PR TITLE
add `kubernetes.io/metadata.name` annotation for default namespace rebaseRules

### DIFF
--- a/pkg/kapp/config/default.go
+++ b/pkg/kapp/config/default.go
@@ -67,6 +67,14 @@ rebaseRules:
   resourceMatchers:
   - apiVersionKindMatcher: {apiVersion: v1, kind: Namespace}
 
+# Kubernetes adds a label to namespaces
+- paths:
+  - [metadata, annotations, kubernetes.io/metadata.name]
+  type: copy
+  sources: [new, existing]
+  resourceMatchers:
+  - apiVersionKindMatcher: {apiVersion: v1, kind: Namespace}
+
 # PVC
 - paths:
   - [metadata, annotations, pv.kubernetes.io/bind-completed]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

[`kubernetes.io/metadata.name`](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name) annotation is not a part of default rebase rules for namespace, added it in this pr.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
