### PR TITLE
Replace hardcoded shebangs with /usr/bin/env for portability

### DIFF
--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -u
 

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -u
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -u
 

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 golangci-lint cache clean

--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -u
 

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -o pipefail
 

--- a/hack/test-external-loop-cert-manager.sh
+++ b/hack/test-external-loop-cert-manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -u
 

--- a/hack/test-external.sh
+++ b/hack/test-external.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x -u
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x
 

--- a/hack/verify-no-dirty-files.sh
+++ b/hack/verify-no-dirty-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Replaces hardcoded shebang paths (`#!/bin/bash` and `#!/bin/sh`) with portable versions (`#!/usr/bin/env bash` and `#!/usr/bin/env sh`) in all shell scripts in the `hack/` directory.

This improves portability across different Unix-like systems where shell interpreters may not be in standard locations, such as:
- **NixOS**: Bash is located at `/run/current-system/sw/bin/bash`
- **BSD variants**: May have bash in `/usr/local/bin/bash`
- **Custom environments**: Where bash is installed in non-standard locations

Using `/usr/bin/env` is the POSIX-recommended approach and is already widely adopted in the Go ecosystem.

#### Which issue(s) this PR fixes:

Fixes #1104

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional Notes for your reviewer:

This is a straightforward portability fix that doesn't change any functionality. All 10 shell scripts in the `hack/` directory have been updated. The scripts will continue to work exactly as before on systems with bash in `/bin/bash`, while now also working on systems where bash is in other locations.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated (N/A - shebang-only change)
- [x] Relevant docs in this repo added or updated (N/A - no doc changes needed)
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR (N/A - no doc changes needed)
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
N/A
```
