### PR TITLE
Fix long CRD change group validation

### DIFF
--- a/pkg/kapp/diffgraph/change_group.go
+++ b/pkg/kapp/diffgraph/change_group.go
@@ -52,8 +52,9 @@ func (r ChangeGroup) isQualifiedNameWithoutLen(name string) []string {
 	errStrs := k8sval.IsQualifiedName(name)
 	var updatedErrStrs []string
 	for _, err := range errStrs {
-		// Allow change group names to have more characters than the default maxLength
-		if !strings.Contains(err, k8sval.MaxLenError(k8sval.DNS1035LabelMaxLength)) {
+		// Allow change group names to have more characters than the default maxLength.
+		// k8s has used both "characters" and "bytes" wording across versions.
+		if !strings.Contains(err, "must be no more than 63 ") {
 			updatedErrStrs = append(updatedErrStrs, err)
 		}
 	}

--- a/pkg/kapp/diffgraph/change_group_test.go
+++ b/pkg/kapp/diffgraph/change_group_test.go
@@ -22,6 +22,8 @@ func TestNewChangeGroupFromAnnString(t *testing.T) {
 		"valid-name.com/valid-name_CustomResourceDefinition--valid",
 		// Example from pinniped of a long name
 		"change-groups.kapp.k14s.io/crds-authentication.concierge.pinniped.dev-WebhookAuthenticator",
+		// Regression test for #1123: long CRD group + kind can exceed 63 bytes.
+		"change-groups.kapp.k14s.io/crds-fooooooooooooooooooooooooooooooooooooooooooooooooooooo.example.com-SomeLongCRDName",
 	}
 	for _, name := range names {
 		cg, err := ctldgraph.NewChangeGroupFromAnnString(name)


### PR DESCRIPTION
## Summary
- fix change-group qualified-name validation to ignore max-length errors across Kubernetes wording variants
- add a regression test for long CRD-derived change-group names

## Why
kapp allows long CRD-derived change-group names, but newer Kubernetes validation returns a length error string with "bytes" wording that was no longer filtered, causing regressions.

Closes #1123.