### PR TITLE
Update Go version to 1.25.11 to address GO-2026-5038 / CVE-2026-42504

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/kapp
 
-go 1.25.10
+go 1.25.11
 
 require (
 	carvel.dev/kapp-controller v0.59.8


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

Updates the Go version to 1.25.11 to address vulnerability [GO-2026-5038](https://pkg.go.dev/vuln/GO-2026-5038) aka. [CVE-2026-42504](https://www.cve.org/CVERecord?id=CVE-2026-42504) .

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
